### PR TITLE
make jnr-ffi and jnr-constants first class dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,13 +71,11 @@
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
       <version>0.6.1-SNAPSHOT</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-constants</artifactId>
       <version>0.8.2</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
 jnr-ffi and jnr-constants are _not_ actually provided by something else in the runtime, they are genuine dependencies.
