### PR TITLE
Chmod incorrectly says that it failed to modify the permission

### DIFF
--- a/src/main/java/jnr/posix/util/Chmod.java
+++ b/src/main/java/jnr/posix/util/Chmod.java
@@ -51,6 +51,7 @@ public class Chmod {
             // group and setuid/gid are ignored, no way to do them fast. Should we fall back on slow?
             if (!setPermissions(file, other, false)) return -1;
             if (!setPermissions(file, user, true)) return -1;
+            return 0;
         } else {
             // slow version
             try {

--- a/src/test/java/jnr/posix/JavaPOSIXTest.java
+++ b/src/test/java/jnr/posix/JavaPOSIXTest.java
@@ -5,6 +5,9 @@
 
 package jnr.posix;
 
+import java.io.File;
+import java.io.IOException;
+
 import jnr.posix.JavaPOSIX;
 import jnr.posix.POSIX;
 import jnr.posix.Passwd;
@@ -50,6 +53,20 @@ public class JavaPOSIXTest {
     @Test public void uid() {
         
     }
+
+	@Test
+	public void chmodTest() throws IOException {
+		// create a tmp file
+		String fName = "test.dat";
+		File file = new File(fName);
+		file.createNewFile();
+		// test ..
+		assertEquals("chmod: ", 0, posix.chmod(fName, 0));
+		assertEquals("chmod: ", 0, posix.chmod(fName, 0777));
+		// .. and delete
+		file.delete();
+	}
+
     @Test public void getpwuid() {
         Passwd pwd = posix.getpwuid(posix.getuid());
         assertNotNull("getpwuid failed", pwd);


### PR DESCRIPTION
util/Chmod.java uses reflection to set the requested permissions on a given file, but it does not report back that it was successful. It will return -1 even if the permissions were changed successfully. 

The patch adds a return 0 to the code path and also includes a test case to test it.
