### PR TITLE
Fix stat() on Solaris

### DIFF
--- a/src/org/jruby/ext/posix/SolarisPOSIX.java
+++ b/src/org/jruby/ext/posix/SolarisPOSIX.java
@@ -21,7 +21,7 @@ final class SolarisPOSIX extends BaseNativePOSIX {
         FileStat stat = allocateStat();
         int fd = helper.getfd(fileDescriptor);
 
-        if ((Platform.IS_64_BIT ? libc().fstat64(fd, stat) : libc().fstat(fd, stat)) < 0) handler.error(ENOENT, ""+fd);
+        if ((Platform.IS_32_BIT ? libc().fstat64(fd, stat) : libc().fstat(fd, stat)) < 0) handler.error(ENOENT, ""+fd);
         
         return stat;
     }
@@ -35,12 +35,12 @@ final class SolarisPOSIX extends BaseNativePOSIX {
     
     @Override
     public int lstat(String path, FileStat stat) {
-        return Platform.IS_64_BIT ? libc().lstat64(path, stat) : libc().lstat(path, stat);
+        return Platform.IS_32_BIT ? libc().lstat64(path, stat) : libc().lstat(path, stat);
     }
     
     @Override
     public int stat(String path, FileStat stat) {
-        return Platform.IS_64_BIT ? libc().stat64(path, stat) : libc().stat(path, stat);
+        return Platform.IS_32_BIT ? libc().stat64(path, stat) : libc().stat(path, stat);
     }
     
     public static final PointerConverter PASSWD = new PointerConverter() {


### PR DESCRIPTION
The 64-bitness tests in SolarisPOSIX.java are the wrong way round - 32 bit Solaris has a stat64(), but 64 bit Solaris just has stat().
## jruby-1.6

I've got a working version of JRuby 1.6.7.2 by building a new version of the jruby-1_6 branch with this change, then updating jruby.jar with:

jar uf jruby.jar org/jruby/ext/posix/*
jar uf jruby.jar org/jruby/ext/posix/util/*
## master

For master, revert this change:

https://github.com/jnr/jnr-posix/commit/002c01984349fb4df43d19a71d07b8d68792946c

then apply this commit.
