### PR TITLE
Solaris fix

### DIFF
--- a/src/main/java/jnr/posix/SolarisPOSIX.java
+++ b/src/main/java/jnr/posix/SolarisPOSIX.java
@@ -23,7 +23,7 @@ final class SolarisPOSIX extends BaseNativePOSIX {
         FileStat stat = allocateStat();
         int fd = helper.getfd(fileDescriptor);
 
-        if (libc().fstat64(fd, stat) < 0) handler.error(ENOENT, ""+fd);
+        if ((Platform.IS_32_BIT ? libc().fstat64(fd, stat) : libc().fstat(fd, stat)) < 0) handler.error(ENOENT, ""+fd);
         
         return stat;
     }
@@ -37,12 +37,12 @@ final class SolarisPOSIX extends BaseNativePOSIX {
     
     @Override
     public int lstat(String path, FileStat stat) {
-        return libc().lstat64(path, stat);
+        return Platform.IS_32_BIT ? libc().lstat64(path, stat) : libc().lstat(path, stat);
     }
     
     @Override
     public int stat(String path, FileStat stat) {
-        return libc().stat64(path, stat);
+        return Platform.IS_32_BIT ? libc().stat64(path, stat) : libc().stat(path, stat);
     }
 
 


### PR DESCRIPTION
Fix for Solaris 10: 64 bit version only has a stat().

I've emailed a x86_64-SunOS/libjffi-1.2.so to @enebo .

This is the solution suggested in #9 as a tested commit.
