### PR TITLE
implement chdir(path) on Windows

### DIFF
--- a/src/main/java/jnr/posix/WindowsLibC.java
+++ b/src/main/java/jnr/posix/WindowsLibC.java
@@ -33,6 +33,7 @@ public interface WindowsLibC extends LibC {
     public int _wmkdir(@In WString path);
     public boolean RemoveDirectoryW(@In WString path);
     public int _wchmod(@In WString path, int pmode);
+    public int _wchdir(@In WString path);
     
     @StdCall
     public boolean CreateProcessW(byte[] applicationName, 

--- a/src/main/java/jnr/posix/WindowsPOSIX.java
+++ b/src/main/java/jnr/posix/WindowsPOSIX.java
@@ -147,6 +147,11 @@ final class WindowsPOSIX extends BaseNativePOSIX {
     public int chmod(String filename, int mode) {
         return wlibc()._wchmod(WString.path(filename), mode);
     }
+
+    @Override
+    public int chdir(String path) {
+        return wlibc()._wchdir(WString.path(path));
+    }
     
     @Override
     public int chown(String filename, int user, int group) {


### PR DESCRIPTION
chdir is not implemented on Windows.
fix #28 

jruby/jruby#1115 might be improved by this.
