### PR TITLE
Sync with OpenBSD changes wrt 64-bit types.

### DIFF
--- a/src/main/java/jnr/posix/OpenBSDFileStat.java
+++ b/src/main/java/jnr/posix/OpenBSDFileStat.java
@@ -40,17 +40,16 @@ public final class OpenBSDFileStat extends BaseFileStat {
             super(runtime);
         }
 
-        public final class time_t extends Signed32 {}
+        public final class time_t extends Signed64 {}
         public final class dev_t extends Signed32 {}
 
-        public final dev_t  st_dev = new dev_t();
-        public final Unsigned32  st_ino = new Unsigned32();
         public final Unsigned32  st_mode = new Unsigned32();
+        public final dev_t  st_dev = new dev_t();
+        public final Unsigned64  st_ino = new Unsigned64();
         public final Unsigned32  st_nlink = new Unsigned32();
         public final Unsigned32  st_uid = new Unsigned32();
         public final Unsigned32  st_gid = new Unsigned32();
         public final dev_t  st_rdev = new dev_t();
-        public final Signed32  st_lspare0 = new Signed32();
         public final time_t st_atime = new time_t();
         public final SignedLong   st_atimensec = new SignedLong();
         public final time_t st_mtime = new time_t();
@@ -62,11 +61,8 @@ public final class OpenBSDFileStat extends BaseFileStat {
         public final Unsigned32  st_blksize = new Unsigned32();
         public final Unsigned32  st_flags = new Unsigned32();
         public final Unsigned32  st_gen = new Unsigned32();
-        public final Signed32  st_lspare1 = new Signed32();
         public final time_t st_birthtime = new time_t();
         public final SignedLong   st_birthtimensec = new SignedLong();
-        public final Signed64  st_qspare0 = new Signed64();
-        public final Signed64  st_qspare1 = new Signed64();
     }
     private static final Layout layout = new Layout(jnr.ffi.Runtime.getSystemRuntime());
     public OpenBSDFileStat(NativePOSIX posix) {

--- a/src/main/java/jnr/posix/OpenBSDPasswd.java
+++ b/src/main/java/jnr/posix/OpenBSDPasswd.java
@@ -43,14 +43,14 @@ public class OpenBSDPasswd extends NativePasswd implements Passwd {
 
         public final UTF8StringRef pw_name = new UTF8StringRef();   // user name
         public final UTF8StringRef pw_passwd = new UTF8StringRef(); // password (encrypted)
-        public final Signed32 pw_uid = new Signed32();       // user id
-        public final Signed32 pw_gid = new Signed32();       // user id
-        public final SignedLong pw_change = new SignedLong();    // password change time
+        public final Unsigned32 pw_uid = new Unsigned32();       // user id
+        public final Unsigned32 pw_gid = new Unsigned32();       // user id
+        public final Signed64 pw_change = new Signed64();    // password change time
         public final UTF8StringRef pw_class = new UTF8StringRef();  // user access class
         public final UTF8StringRef pw_gecos = new UTF8StringRef();  // login info
         public final UTF8StringRef pw_dir = new UTF8StringRef();    // home directory
         public final UTF8StringRef pw_shell = new UTF8StringRef();  // default shell
-        public final SignedLong pw_expire = new SignedLong();    // account expiration
+        public final Signed64 pw_expire = new Signed64();    // account expiration
     }
     private static final Layout layout = new Layout(jnr.ffi.Runtime.getSystemRuntime());
 


### PR DESCRIPTION
OpenBSD moved from 32-bit time_t to 64-bit time_t (along with several other
type changes). This brings jnr-posix back in sync OpenBSD and effectively
unbreaking it on OpenBSD >= 5.5.

This uses @jeremyevans's patch from #15 . We (Jeremy and I) propose to merge this patch, and thus not include backwards compat for OpenBSD 5.4 and earlier. These releases will not be supported by OpenBSD in 4 weeks from now so there is little merit for jnr-posix to keep supporting it either.
