### PR TITLE
Fix OpenBSDTimeval on i386

### DIFF
--- a/src/main/java/jnr/posix/OpenBSDTimeval.java
+++ b/src/main/java/jnr/posix/OpenBSDTimeval.java
@@ -1,7 +1,7 @@
 package jnr.posix;
 
 public final class OpenBSDTimeval extends Timeval {
-    public final SignedLong tv_sec = new SignedLong();
+    public final Signed64 tv_sec = new Signed64();
     public final SignedLong tv_usec = new SignedLong();
 
     public OpenBSDTimeval(jnr.ffi.Runtime runtime) {


### PR DESCRIPTION
On OpenBSD 5.5+, time_t is always a signed 64-bit integer.
I've tested this on i386 and amd64 via File.utime in JRuby
and it works correctly.
