### PR TITLE
Add long-taking preferred version of kill

### DIFF
--- a/src/main/java/jnr/posix/BaseNativePOSIX.java
+++ b/src/main/java/jnr/posix/BaseNativePOSIX.java
@@ -244,9 +244,13 @@ abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
     }
 
     public int kill(int pid, int signal) {
+        return kill((long) pid, signal);
+    }
+
+    public int kill(long pid, int signal) {
         return libc().kill(pid, signal);
     }
-    
+
     public SignalHandler signal(Signal sig, final SignalHandler handler) {
         synchronized (signalHandlers) {
             SignalHandler old = signalHandlers.get(sig);

--- a/src/main/java/jnr/posix/CheckedPOSIX.java
+++ b/src/main/java/jnr/posix/CheckedPOSIX.java
@@ -207,8 +207,11 @@ final class CheckedPOSIX implements POSIX {
     public boolean isatty(FileDescriptor descriptor) {
         try { return posix.isatty(descriptor); } catch (UnsatisfiedLinkError ule) { return unimplementedBool(); }
     }
-
     public int kill(int pid, int signal) {
+        return kill((long) pid, signal);
+    }
+
+    public int kill(long pid, int signal) {
         try { return posix.kill(pid, signal); } catch (UnsatisfiedLinkError ule) { return unimplementedInt(); }
     }
 

--- a/src/main/java/jnr/posix/JavaPOSIX.java
+++ b/src/main/java/jnr/posix/JavaPOSIX.java
@@ -219,7 +219,11 @@ final class JavaPOSIX implements POSIX {
     public int kill(int pid, int signal) {
         return unimplementedInt("kill");    // FIXME: Can be implemented
     }
-    
+
+    public int kill(long pid, int signal) {
+        return unimplementedInt("kill");    // FIXME: Can be implemented
+    }
+
     private static class SunMiscSignalHandler implements sun.misc.SignalHandler {
         final SignalHandler handler;
         public SunMiscSignalHandler(SignalHandler handler) {

--- a/src/main/java/jnr/posix/LazyPOSIX.java
+++ b/src/main/java/jnr/posix/LazyPOSIX.java
@@ -206,6 +206,10 @@ final class LazyPOSIX implements POSIX {
     }
 
     public int kill(int pid, int signal) {
+        return kill((long) pid, signal);
+    }
+
+    public int kill(long pid, int signal) {
         return posix().kill(pid, signal);
     }
     

--- a/src/main/java/jnr/posix/LibC.java
+++ b/src/main/java/jnr/posix/LibC.java
@@ -73,7 +73,7 @@ public interface LibC {
     @IgnoreError int getuid();
     int setsid();
     int setuid(int uid);
-    int kill(int pid, int signal);
+    int kill(long pid, int signal);
 
     int dup(int fd);
     int dup2(int oldFd, int newFd);

--- a/src/main/java/jnr/posix/POSIX.java
+++ b/src/main/java/jnr/posix/POSIX.java
@@ -62,6 +62,7 @@ public interface  POSIX {
     int getuid();
     boolean isatty(FileDescriptor descriptor);
     int kill(int pid, int signal);
+    int kill(long pid, int signal);
     SignalHandler signal(Signal sig, SignalHandler handler);
     int lchmod(String filename, int mode);
     int lchown(String filename, int user, int group);

--- a/src/main/java/jnr/posix/WindowsPOSIX.java
+++ b/src/main/java/jnr/posix/WindowsPOSIX.java
@@ -144,6 +144,13 @@ final class WindowsPOSIX extends BaseNativePOSIX {
     }
 
     @Override
+    public int kill(long pid, int signal) {
+        handler.unimplementedError("kill");
+
+        return -1;
+    }
+
+    @Override
     public int chmod(String filename, int mode) {
         return wlibc()._wchmod(WString.path(filename), mode);
     }


### PR DESCRIPTION
Depending on platform a PID might not fit in an int.

I followed the example of fed067f035f47166ae8de3894a572c7d6354a73c and created a second long-receiving version.