### PR TITLE
LinuxFileStat32/64 nano second support

### DIFF
--- a/src/main/java/jnr/posix/LinuxFileStat32.java
+++ b/src/main/java/jnr/posix/LinuxFileStat32.java
@@ -75,6 +75,10 @@ public final class LinuxFileStat32 extends BaseFileStat {
         return layout.st_atim_sec.get(memory);
     }
 
+    public long aTimeNanoSecs() {
+        return layout.st_atim_nsec.get(memory);
+    }
+
     public long blocks() {
         return layout.st_blocks.get(memory);
     }
@@ -85,6 +89,10 @@ public final class LinuxFileStat32 extends BaseFileStat {
 
     public long ctime() {
         return layout.st_ctim_sec.get(memory);
+    }
+
+    public long cTimeNanoSecs() {
+        return layout.st_ctim_nsec.get(memory);
     }
 
     public long dev() {
@@ -105,6 +113,10 @@ public final class LinuxFileStat32 extends BaseFileStat {
 
     public long mtime() {
         return layout.st_mtim_sec.get(memory);
+    }
+
+    public long mTimeNanoSecs() {
+        return layout.st_mtim_nsec.get(memory);
     }
 
     public int nlink() {

--- a/src/main/java/jnr/posix/LinuxFileStat64.java
+++ b/src/main/java/jnr/posix/LinuxFileStat64.java
@@ -40,6 +40,10 @@ public final class LinuxFileStat64 extends BaseFileStat {
         return layout.st_atime.get(memory);
     }
 
+    public long aTimeNanoSecs() {
+        return layout.st_atimensec.get(memory);
+    }
+
     public long blockSize() {
         return layout.st_blksize.get(memory);
     }
@@ -50,6 +54,10 @@ public final class LinuxFileStat64 extends BaseFileStat {
 
     public long ctime() {
         return layout.st_ctime.get(memory);
+    }
+
+    public long cTimeNanoSecs() {
+        return layout.st_ctimensec.get(memory);
     }
 
     public long dev() {
@@ -70,6 +78,10 @@ public final class LinuxFileStat64 extends BaseFileStat {
 
     public long mtime() {
         return layout.st_mtime.get(memory);
+    }
+
+    public long mTimeNanoSecs() {
+        return layout.st_mtimensec.get(memory);
     }
 
     public int nlink() {


### PR DESCRIPTION
LinuxFileStat32/64 classes do not support to a/c/m nsec parameters (even though parameters are available in the layout)
It would be great, if we can provide the public methods to access these parameters :)