### PR TITLE
Add OSGi metadata to jnr-posix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,11 +100,34 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <configuration>
+          <instructions>
+            <Implementation-Title>JNA-POSIX</Implementation-Title>
+            <Implementation-Version>0.5</Implementation-Version>
+            <_nouses>true</_nouses>
+            <Import-Package>!sun.misc,*</Import-Package>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.3.1</version>
         <configuration>
           <archive>
-            <manifestFile>MANIFEST.MF</manifestFile>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
Use maven-bundle-plugin to generate OSGi metadata and include the
manifest using maven-jar-plugin.

This change only adds additional entries to the MANIFEST.MF shipped in the final jar artifact. The attributes would not affect current consumers of this artifact.