### PR TITLE
Reduce access restrictions to facilitate extension

### DIFF
--- a/src/main/java/jnr/posix/BaseNativePOSIX.java
+++ b/src/main/java/jnr/posix/BaseNativePOSIX.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import jnr.constants.platform.Signal;
 
-abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
+public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
     private final LibC libc;
     
     protected final POSIXHandler handler;
@@ -31,7 +31,7 @@ abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
     
     protected final Map<Signal, SignalHandler> signalHandlers = new HashMap();
     
-    BaseNativePOSIX(LibCProvider libcProvider, POSIXHandler handler) {
+    protected BaseNativePOSIX(LibCProvider libcProvider, POSIXHandler handler) {
         this.handler = handler;
         this.libc = libcProvider.getLibC();
         this.helper = new JavaLibCHelper(handler);

--- a/src/main/java/jnr/posix/NativeGroup.java
+++ b/src/main/java/jnr/posix/NativeGroup.java
@@ -5,7 +5,7 @@ import jnr.ffi.StructLayout;
 public abstract class NativeGroup implements Group {
     protected final jnr.ffi.Runtime runtime;
     protected final StructLayout structLayout;
-    NativeGroup(jnr.ffi.Runtime runtime, StructLayout structLayout) {
+    protected NativeGroup(jnr.ffi.Runtime runtime, StructLayout structLayout) {
         this.runtime = runtime;
         this.structLayout = structLayout;
     }

--- a/src/main/java/jnr/posix/NativePOSIX.java
+++ b/src/main/java/jnr/posix/NativePOSIX.java
@@ -3,13 +3,13 @@ package jnr.posix;
 /**
  *
  */
-abstract class NativePOSIX implements POSIX {
+public abstract class NativePOSIX implements POSIX {
 
 
     jnr.ffi.Runtime getRuntime() {
         return jnr.ffi.Runtime.getRuntime(libc());
     }
 
-    abstract SocketMacros socketMacros();
+    public abstract SocketMacros socketMacros();
 
 }

--- a/src/main/java/jnr/posix/NativeTimes.java
+++ b/src/main/java/jnr/posix/NativeTimes.java
@@ -9,7 +9,7 @@ import jnr.ffi.StructLayout;
 /**
  *
  */
-final class NativeTimes implements Times {
+public final class NativeTimes implements Times {
     static final class Layout extends StructLayout {
         public final clock_t tms_utime = new clock_t();
         public final clock_t tms_stime = new clock_t();


### PR DESCRIPTION
This pull request is to make it possible to provide alternative implementations of the POSIX and LibC interfaces outside of the jnr.posix package. This makes package private members visible that either must be available because they are used as parameters in the interface, or would be useful to subclass for an alternative implementation.