### PR TITLE
Implement ioprio_get/ioprio_set on Linux

### DIFF
--- a/src/main/java/jnr/posix/LibC.java
+++ b/src/main/java/jnr/posix/LibC.java
@@ -154,5 +154,10 @@ public interface LibC {
     int recvmsg(int socket, @Direct MsgHdr message, int flags);
 
     Variable<Long> environ();
+
+    int syscall(int number);
+    int syscall(int number, int arg1);
+    int syscall(int number, int arg1, int arg2);
+    int syscall(int number, int arg1, int arg2, int arg3);
 }
 

--- a/src/main/java/jnr/posix/LinuxIoPrio.java
+++ b/src/main/java/jnr/posix/LinuxIoPrio.java
@@ -1,0 +1,24 @@
+package jnr.posix;
+
+public abstract class LinuxIoPrio {
+    static int IOPRIO_WHO_PROCESS = 1;
+    static int IOPRIO_WHO_PGRP = 2;
+    static int IOPRIO_WHO_USER = 3;
+
+    static int IOPRIO_CLASS_NONE = 0;
+    static int IOPRIO_CLASS_RT = 1;
+    static int IOPRIO_CLASS_BE = 2;
+    static int IOPRIO_CLASS_IDLE = 3;
+
+    public static int IOPRIO_PRIO_VALUE(int _class, int data) {
+        return (_class << 13) | data;
+    }
+
+    public static int IOPRIO_PRIO_CLASS(int mask) {
+        return mask >> 13;
+    }
+
+    public static int IOPRIO_PRIO_DATA(int mask) {
+        return mask & 0x0f;
+    }
+}

--- a/src/main/java/jnr/posix/LinuxPOSIX.java
+++ b/src/main/java/jnr/posix/LinuxPOSIX.java
@@ -177,4 +177,69 @@ final class LinuxPOSIX extends BaseNativePOSIX {
             return arg != null ? new LinuxPasswd((Pointer) arg) : null;
         }
     };
+
+    static final public class Syscall {
+        static final ABI _ABI_X86_32 = new ABI_X86_32();
+        static final ABI _ABI_X86_64 = new ABI_X86_64();
+
+        public static ABI abi() {
+            if ("x86_64".equals(Platform.ARCH)) {
+                if (Platform.IS_64_BIT) {
+                    return _ABI_X86_64;
+                }
+            } else if ("i386".equals(Platform.ARCH)) {
+                return _ABI_X86_32;
+            }
+            return null;
+        }
+
+        interface ABI {
+            public int __NR_ioprio_set();
+            public int __NR_ioprio_get();
+        }
+
+        /** @see /usr/include/asm/unistd_32.h */
+        final static class ABI_X86_32 implements ABI {
+            @Override
+            public int __NR_ioprio_set() {
+                return 289;
+            }
+            @Override
+            public int __NR_ioprio_get() {
+                return 290;
+            }
+        }
+
+        /** @see /usr/include/asm/unistd_64.h */
+        final static class ABI_X86_64 implements ABI {
+            @Override
+            public int __NR_ioprio_set() {
+                return 251;
+            }
+            @Override
+            public int __NR_ioprio_get() {
+                return 252;
+            }
+        }
+    }
+
+    public int ioprio_get(int which, int who) {
+        Syscall.ABI abi = Syscall.abi();
+        if (abi == null) {
+            handler.unimplementedError("ioprio_get");
+            return -1;
+        }
+
+        return libc().syscall(abi.__NR_ioprio_get(), which, who);
+    }
+
+    public int ioprio_set(int which, int who, int ioprio) {
+        Syscall.ABI abi = Syscall.abi();
+        if (abi == null) {
+            handler.unimplementedError("ioprio_set");
+            return -1;
+        }
+
+        return libc().syscall(abi.__NR_ioprio_set(), which, who, ioprio);
+    }
 }

--- a/src/test/java/jnr/posix/LinuxPOSIXTest.java
+++ b/src/test/java/jnr/posix/LinuxPOSIXTest.java
@@ -1,0 +1,67 @@
+package jnr.posix;
+
+import jnr.ffi.Platform;
+import jnr.posix.util.ConditionalTestRule;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.locks.Lock;
+
+import static jnr.posix.LinuxIoPrio.*;
+
+public class LinuxPOSIXTest {
+
+    @ClassRule
+    public static RunningOnLinux rule = new RunningOnLinux();
+
+    private static LinuxPOSIX linuxPOSIX = null;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        POSIX posix = POSIXFactory.getNativePOSIX();
+
+        if (posix instanceof LinuxPOSIX) {
+            linuxPOSIX = (LinuxPOSIX) posix;
+        }
+    }
+
+    /**
+     * Tests that IO priority can be set to a thread and that it doesn't change priority set on
+     * another thread
+     * @throws InterruptedException
+     * @throws ExecutionException
+     */
+    @Test
+    public void ioprioThreadedTest() throws InterruptedException, ExecutionException {
+        linuxPOSIX.ioprio_set(IOPRIO_WHO_PROCESS, 0, IOPRIO_PRIO_VALUE(IOPRIO_CLASS_BE, 4));
+
+        Future<Integer> threadPriorityFuture = Executors.newFixedThreadPool(1).submit(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                linuxPOSIX.ioprio_set(IOPRIO_WHO_PROCESS, 0, IOPRIO_PRIO_VALUE(IOPRIO_CLASS_IDLE, 7));
+                return linuxPOSIX.ioprio_get(IOPRIO_WHO_PROCESS, 0);
+            }
+        });
+
+        int threadPriority = threadPriorityFuture.get().intValue();
+
+        Assert.assertEquals(7, IOPRIO_PRIO_DATA(threadPriority));
+        Assert.assertEquals(IOPRIO_CLASS_IDLE, IOPRIO_PRIO_CLASS(threadPriority));
+        Assert.assertEquals(4, IOPRIO_PRIO_DATA(linuxPOSIX.ioprio_get(IOPRIO_WHO_PROCESS, 0)));
+        Assert.assertEquals(IOPRIO_CLASS_BE, IOPRIO_PRIO_CLASS(linuxPOSIX.ioprio_get(IOPRIO_WHO_PROCESS, 0)));
+    }
+}
+
+class RunningOnLinux extends ConditionalTestRule {
+    public boolean isSatisfied() {
+        return jnr.ffi.Platform.getNativePlatform().getOS().equals(Platform.OS.LINUX);
+    }
+}

--- a/src/test/java/jnr/posix/util/ConditionalTestRule.java
+++ b/src/test/java/jnr/posix/util/ConditionalTestRule.java
@@ -1,0 +1,23 @@
+package jnr.posix.util;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public abstract class ConditionalTestRule implements TestRule {
+    public Statement apply(Statement base, Description description) {
+        return statement(base);
+    }
+
+    private Statement statement(final Statement base) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                if (isSatisfied()) {
+                    base.evaluate();
+                }
+            }
+        };
+    }
+    public abstract  boolean isSatisfied();
+}


### PR DESCRIPTION
This patch implements Linux a specific calls to set IO priority on processes.

As ioprio_get and ioprio_set system calls don't have a wrapper in glibc, I needed to use glibc syscall helper to implement.