### PR TITLE
WIP: fix stat.isWritable() regression on Windows

### DIFF
--- a/src/main/java/jnr/posix/util/Platform.java
+++ b/src/main/java/jnr/posix/util/Platform.java
@@ -11,8 +11,8 @@
  * implied. See the License for the specific language governing
  * rights and limitations under the License.
  *
- * 
- *  
+ *
+ *
  * Alternatively, the contents of this file may be used under the terms of
  * either of the GNU General Public License Version 2 or later (the "GPL"),
  * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
@@ -48,6 +48,7 @@ public class Platform {
     private static final String WINDOWS_SERVER = "server";
     private static final String WINDOWS_VISTA = "vista";
     private static final String WINDOWS_7 = "windows 7";
+    private static final String WINDOWS_8 = "windows 8";
     private static final String MAC_OS = "mac os";
     private static final String DARWIN = "darwin";
     private static final String FREEBSD = "freebsd";
@@ -65,20 +66,24 @@ public class Platform {
     public static final boolean IS_WINDOWS_VISTA = IS_WINDOWS && OS_NAME_LC.indexOf(WINDOWS_VISTA) > -1;
     public static final boolean IS_WINDOWS_SERVER = IS_WINDOWS && OS_NAME_LC.indexOf(WINDOWS_SERVER) > -1;
     public static final boolean IS_WINDOWS_7 = IS_WINDOWS && OS_NAME_LC.indexOf(WINDOWS_7) > -1;
+    public static final boolean IS_WINDOWS_8 = IS_WINDOWS && OS_NAME_LC.indexOf(WINDOWS_8) > -1;
     public static final boolean IS_MAC = OS_NAME_LC.startsWith(MAC_OS) || OS_NAME_LC.startsWith(DARWIN);
     public static final boolean IS_FREEBSD = OS_NAME_LC.startsWith(FREEBSD);
     public static final boolean IS_OPENBSD = OS_NAME_LC.startsWith(OPENBSD);
-    public static final boolean IS_LINUX = OS_NAME_LC.startsWith(LINUX);   
+    public static final boolean IS_LINUX = OS_NAME_LC.startsWith(LINUX);
     public static final boolean IS_SOLARIS = OS_NAME_LC.startsWith(SOLARIS);
     public static final boolean IS_BSD = IS_MAC || IS_FREEBSD || IS_OPENBSD;
-    
-    public static final String envCommand() {
+
+    public static final String envCommand() throws Exception {
         if (IS_WINDOWS) {
             if (IS_WINDOWS_9X) {
                 return "command.com /c set";
             } else if (IS_WINDOWS_NT || IS_WINDOWS_20X || IS_WINDOWS_XP ||
-                       IS_WINDOWS_SERVER || IS_WINDOWS_VISTA || IS_WINDOWS_7) {
+                       IS_WINDOWS_SERVER || IS_WINDOWS_VISTA ||
+                       IS_WINDOWS_7 || IS_WINDOWS_8) {
                 return "cmd.exe /c set";
+            } else {
+              throw new Exception("Unsupported version of Windows detected: " + OS_NAME_LC);
             }
         }
         return "env";
@@ -93,7 +98,7 @@ public class Platform {
         if (arch.equals("amd64")) arch = "x86_64";
         ARCH = arch;
     }
-    
+
     public static final Map<String, String> OS_NAMES = new HashMap<String, String>();
     static {
         OS_NAMES.put("Mac OS X", DARWIN);
@@ -101,12 +106,12 @@ public class Platform {
         OS_NAMES.put("Linux", LINUX);
     }
 
-    public static String getOSName()  {
+    public static String getOSName() {
         String theOSName = OS_NAMES.get(OS_NAME);
-        
+
         return theOSName == null ? OS_NAME : theOSName;
     }
-    
+
     /**
      * An extension over <code>System.getProperty</code> method.
      * Handles security restrictions, and returns the default

--- a/src/main/java/jnr/posix/util/Platform.java
+++ b/src/main/java/jnr/posix/util/Platform.java
@@ -49,6 +49,7 @@ public class Platform {
     private static final String WINDOWS_VISTA = "vista";
     private static final String WINDOWS_7 = "windows 7";
     private static final String WINDOWS_8 = "windows 8";
+    private static final String WINDOWS_10 = "windows 10";
     private static final String MAC_OS = "mac os";
     private static final String DARWIN = "darwin";
     private static final String FREEBSD = "freebsd";
@@ -66,7 +67,9 @@ public class Platform {
     public static final boolean IS_WINDOWS_VISTA = IS_WINDOWS && OS_NAME_LC.indexOf(WINDOWS_VISTA) > -1;
     public static final boolean IS_WINDOWS_SERVER = IS_WINDOWS && OS_NAME_LC.indexOf(WINDOWS_SERVER) > -1;
     public static final boolean IS_WINDOWS_7 = IS_WINDOWS && OS_NAME_LC.indexOf(WINDOWS_7) > -1;
+    // Note: JDK < 8u60 incorrectly reports 'Windows 8.1' for Windows 10: https://bugs.openjdk.java.net/browse/JDK-8066504
     public static final boolean IS_WINDOWS_8 = IS_WINDOWS && OS_NAME_LC.indexOf(WINDOWS_8) > -1;
+    public static final boolean IS_WINDOWS_10 = IS_WINDOWS && OS_NAME_LC.indexOf(WINDOWS_10) > -1;
     public static final boolean IS_MAC = OS_NAME_LC.startsWith(MAC_OS) || OS_NAME_LC.startsWith(DARWIN);
     public static final boolean IS_FREEBSD = OS_NAME_LC.startsWith(FREEBSD);
     public static final boolean IS_OPENBSD = OS_NAME_LC.startsWith(OPENBSD);
@@ -74,16 +77,12 @@ public class Platform {
     public static final boolean IS_SOLARIS = OS_NAME_LC.startsWith(SOLARIS);
     public static final boolean IS_BSD = IS_MAC || IS_FREEBSD || IS_OPENBSD;
 
-    public static final String envCommand() throws Exception {
+    public static final String envCommand() {
         if (IS_WINDOWS) {
             if (IS_WINDOWS_9X) {
                 return "command.com /c set";
-            } else if (IS_WINDOWS_NT || IS_WINDOWS_20X || IS_WINDOWS_XP ||
-                       IS_WINDOWS_SERVER || IS_WINDOWS_VISTA ||
-                       IS_WINDOWS_7 || IS_WINDOWS_8) {
-                return "cmd.exe /c set";
             } else {
-              throw new Exception("Unsupported version of Windows detected: " + OS_NAME_LC);
+                return "cmd.exe /c set";
             }
         }
         return "env";

--- a/src/test/java/jnr/posix/FileStatTest.java
+++ b/src/test/java/jnr/posix/FileStatTest.java
@@ -1,4 +1,3 @@
-
 package jnr.posix;
 
 import java.io.FileOutputStream;
@@ -36,7 +35,6 @@ public class FileStatTest {
     public static void setUpClass() throws Exception {
         posix = POSIXFactory.getPOSIX(new DummyPOSIXHandler(), true);
     }
-
 
     @AfterClass
     public static void tearDownClass() throws Exception {
@@ -131,7 +129,7 @@ public class FileStatTest {
         assertTrue(stat == null);
     }
 
-    
+
     @Test public void structStatSize() throws Throwable {
         if (Platform.IS_SOLARIS) {
             jnr.ffi.Runtime runtime = jnr.ffi.Runtime.getSystemRuntime();
@@ -141,7 +139,7 @@ public class FileStatTest {
                 assertEquals("struct size is wrong", 128, new SolarisFileStat64.Layout(runtime).size());
             }
         }
-        
+
         if (Platform.IS_SOLARIS) {
             File f = File.createTempFile("stat", null);
             try {

--- a/src/test/java/jnr/posix/FileStatTest.java
+++ b/src/test/java/jnr/posix/FileStatTest.java
@@ -155,4 +155,12 @@ public class FileStatTest {
             }
         }
     }
+
+    @Test public void statIsWritable() throws Throwable {
+      String tempDirectory = System.getenv("TEMP");
+      FileStat st = posix.stat(tempDirectory);
+
+      // FIXME: This fails on JRuby, but succeeds here. Why?
+      assertTrue("Temp directory incorrectly considered non-writable", st.isWritable());
+    }
 }

--- a/src/test/java/jnr/posix/util/PlatformTest.java
+++ b/src/test/java/jnr/posix/util/PlatformTest.java
@@ -44,7 +44,7 @@ public class PlatformTest extends TestCase {
         assertTrue("Not 32 or 64-bit platform?", Platform.IS_32_BIT ^ Platform.IS_64_BIT);
     }
 
-    public void testEnvCommand()  {
+    public void testEnvCommand() {
         String command = Platform.envCommand();
         if (Platform.IS_WINDOWS_9X)  {
             assertEquals("Fails on Windows 95/98", "command.com /c set", command);

--- a/src/test/java/jnr/posix/util/PlatformTest.java
+++ b/src/test/java/jnr/posix/util/PlatformTest.java
@@ -45,11 +45,11 @@ public class PlatformTest extends TestCase {
     }
 
     public void testEnvCommand()  {
-        String command =Platform.envCommand();
+        String command = Platform.envCommand();
         if (Platform.IS_WINDOWS_9X)  {
             assertEquals("Fails on Windows 95/98", "command.com /c set", command);
         }
-        if (Platform.IS_WINDOWS & !Platform.IS_WINDOWS_9X)  {
+        if (Platform.IS_WINDOWS && !Platform.IS_WINDOWS_9X)  {
             assertEquals("Fails on Windows other than 95/98", "cmd.exe /c set", command);
         }
         if (!Platform.IS_WINDOWS)  {


### PR DESCRIPTION
Note: This is clearly not ready for merge, consider it WIP and a candidate for collaboration.

I've been looking at this issue quite extensively tonight. First fixed one simple test that was failing on Windows 8 and Windows 10 (since the comparison wouldn't include these OS:es; I simplified that part since the previous approach makes it unnecessarily hard to support different Windows versions).

Then, coming to the actual propblem (https://github.com/jruby/jruby/issues/3505) - the weird thing is that the `File.stat('foo').writable?` call in e.g. [File.tmpdir](https://github.com/jruby/jruby/blob/jruby-1_7/lib/ruby/shared/tmpdir.rb#L33) fails. But when I try to reproduce the problem in the `jnr` repo, all is well and things work far too well...

I guess I would have to point my JRuby (using `jruby-complete` unfortunately, which makes it a bit harder) to the `jnr-posix.jar` file I am compiling, to ensure that my JRuby runs towards the same code as the FileStatTest...

Any other obvious suggestions on how to proceed with this?