### PR TITLE
Add POSIX.lutimes.

### DIFF
--- a/src/main/java/jnr/posix/BaseNativePOSIX.java
+++ b/src/main/java/jnr/posix/BaseNativePOSIX.java
@@ -439,6 +439,16 @@ public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
         return libc().futimes(fd, times);
     }
 
+    public int lutimes(String path, long[] atimeval, long[] mtimeval) {
+        Timeval[] times = null;
+        if (atimeval != null && mtimeval != null) {
+            times = Struct.arrayOf(getRuntime(), DefaultNativeTimeval.class, 2);
+            times[0].setTime(atimeval);
+            times[1].setTime(mtimeval);
+        }
+        return libc().lutimes(path, times);
+    }
+
     public int fork() {
         return libc().fork();
     }

--- a/src/main/java/jnr/posix/CheckedPOSIX.java
+++ b/src/main/java/jnr/posix/CheckedPOSIX.java
@@ -360,6 +360,10 @@ final class CheckedPOSIX implements POSIX {
         try { return posix.futimes(fd, atimeval, mtimeval); } catch (UnsatisfiedLinkError ule) { return unimplementedInt(); }
     }
 
+    public int lutimes(String path, long[] atimeval, long[] mtimeval) {
+        try { return posix.lutimes(path, atimeval, mtimeval); } catch (UnsatisfiedLinkError ule) { return unimplementedInt(); }
+    }
+
     public int wait(int[] status) {
         try { return posix.wait(status); } catch (UnsatisfiedLinkError ule) { return unimplementedInt(); }
     }

--- a/src/main/java/jnr/posix/JavaPOSIX.java
+++ b/src/main/java/jnr/posix/JavaPOSIX.java
@@ -449,7 +449,12 @@ final class JavaPOSIX implements POSIX {
         handler.unimplementedError("futimes");
         return unimplementedInt("futimes");
     }
-    
+
+    public int lutimes(String path, long[] atimeval, long[] mtimeval) {
+        handler.unimplementedError("lutimes");
+        return unimplementedInt("lutimes");
+    }
+
     public int wait(int[] status) {
         return unimplementedInt("wait");
     }

--- a/src/main/java/jnr/posix/LazyPOSIX.java
+++ b/src/main/java/jnr/posix/LazyPOSIX.java
@@ -358,6 +358,10 @@ final class LazyPOSIX implements POSIX {
         return posix().futimes(fd, atimeval, mtimeval);
     }
 
+    public int lutimes(String path, long[] atimeval, long[] mtimeval) {
+        return posix().lutimes(path, atimeval, mtimeval);
+    }
+
     public int wait(int[] status) {
         return posix().wait(status);
     }

--- a/src/main/java/jnr/posix/LibC.java
+++ b/src/main/java/jnr/posix/LibC.java
@@ -117,6 +117,7 @@ public interface LibC {
     int utimes(CharSequence path, @In Timeval[] times);
     int utimes(String path, @In Pointer times);
     int futimes(int fd, @In Timeval[] times);
+    int lutimes(CharSequence path, @In Timeval[] times);
     int fork();
     int waitpid(long pid, @Out int[] status, int options);
     int wait(@Out int[] status);

--- a/src/main/java/jnr/posix/POSIX.java
+++ b/src/main/java/jnr/posix/POSIX.java
@@ -109,6 +109,7 @@ public interface  POSIX {
     int utimes(String path, long[] atimeval, long[] mtimeval);
     int utimes(String path, Pointer times);
     int futimes(int fd, long[] atimeval, long[] mtimeval);
+    int lutimes(String path, long[] atimeval, long[] mtimeval);
     int waitpid(int pid, int[] status, int flags);
     int waitpid(long pid, int[] status, int flags);
     int wait(int[] status);

--- a/src/test/java/jnr/posix/FileTest.java
+++ b/src/test/java/jnr/posix/FileTest.java
@@ -110,6 +110,33 @@ public class FileTest {
     }
 
     @Test
+    public void lutimesTest() throws Throwable {
+        // FIXME: On Windows this is working but providing wrong numbers and therefore getting wrong results.
+        if (!Platform.IS_WINDOWS) {
+            File f1 = File.createTempFile("lutimes", null);
+            File f2 = new File(f1.getParentFile(), "lutimes-link");
+            posix.symlink(f1.getAbsolutePath(), f2.getAbsolutePath());
+
+            int rval = posix.utimes(f1.getAbsolutePath(), new long[]{800, 0}, new long[]{900, 0});
+            assertEquals("utimes did not return 0", 0, rval);
+
+            rval = posix.lutimes(f2.getAbsolutePath(), new long[]{1800, 0}, new long[]{1900, 0});
+            assertEquals("lutimes did not return 0", 0, rval);
+
+            FileStat stat = posix.stat(f1.getAbsolutePath());
+            assertEquals("atime seconds failed", 800, stat.atime());
+            assertEquals("mtime seconds failed", 900, stat.mtime());
+
+            stat = posix.lstat(f2.getAbsolutePath());
+            assertEquals("atime seconds failed", 1800, stat.atime());
+            assertEquals("mtime seconds failed", 1900, stat.mtime());
+
+            f1.delete();
+            f2.delete();
+        }
+    }
+
+    @Test
     public void futimeTest() throws Throwable {
         if (!Platform.IS_WINDOWS) {
             File f = File.createTempFile("jnr-posix-futime", "tmp");

--- a/src/test/java/jnr/posix/windows/WindowsFileTest.java
+++ b/src/test/java/jnr/posix/windows/WindowsFileTest.java
@@ -1,6 +1,6 @@
 package jnr.posix.windows;
 
-import java.io.File;;
+import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.text.NumberFormat;


### PR DESCRIPTION
I needed to write the mod time of a symlink itself, which lutimes does, and turns out it was already in LibC, but not the POSIX interface.

I did technically leave in a "fix me on windows" that was from one of the other utimes tests, because I don't have a windows machine to see if that's really true or not for my new test. lutimes seems Unix-y enough that I was just assuming this does not work on Windows.