### PR TITLE
Correct the parameter name for pread()

### DIFF
--- a/src/main/java/jnr/posix/LibC.java
+++ b/src/main/java/jnr/posix/LibC.java
@@ -127,18 +127,18 @@ public interface LibC {
     @ssize_t long write(int fd, @In byte[] src, @size_t long len);
     @ssize_t long read(int fd, @Out ByteBuffer dst, @size_t long len);
     @ssize_t long write(int fd, @In ByteBuffer src, @size_t long len);
-    @ssize_t long pread(int fd, @Out byte[] src, @size_t long len, @off_t long offset);
+    @ssize_t long pread(int fd, @Out byte[] dst, @size_t long len, @off_t long offset);
     @ssize_t long pwrite(int fd, @In byte[] src, @size_t long len, @off_t long offset);
-    @ssize_t long pread(int fd, @Out ByteBuffer src, @size_t long len, @off_t long offset);
+    @ssize_t long pread(int fd, @Out ByteBuffer dst, @size_t long len, @off_t long offset);
     @ssize_t long pwrite(int fd, @In ByteBuffer src, @size_t long len, @off_t long offset);
 
     int read(int fd, @Out byte[] dst, int len);
     int write(int fd, @In byte[] src, int len);
     int read(int fd, @Out ByteBuffer dst, int len);
     int write(int fd, @In ByteBuffer src, int len);
-    int pread(int fd, @Out byte[] src, int len, int offset);
+    int pread(int fd, @Out byte[] dst, int len, int offset);
     int pwrite(int fd, @In byte[] src, int len, int offset);
-    int pread(int fd, @Out ByteBuffer src, int len, int offset);
+    int pread(int fd, @Out ByteBuffer dst, int len, int offset);
     int pwrite(int fd, @In ByteBuffer src, int len, int offset);
 
     long lseek(int fd, long offset, int whence);


### PR DESCRIPTION
pread()'s buffer argument should be called dst instead of src,
like it is for read().