### PR TITLE
Fix allocation of posix_spawnattr_t on Linux

### DIFF
--- a/src/main/java/jnr/posix/BaseNativePOSIX.java
+++ b/src/main/java/jnr/posix/BaseNativePOSIX.java
@@ -575,7 +575,7 @@ public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
     }
 
     private Pointer nativeFileActions(Collection<? extends SpawnFileAction> fileActions) {
-        Pointer nativeFileActions = Memory.allocateDirect(getRuntime(), 128);
+        Pointer nativeFileActions = allocatePosixSpawnFileActions();
         ((UnixLibC) libc()).posix_spawn_file_actions_init(nativeFileActions);
         for (SpawnFileAction action : fileActions) {
             action.act(this, nativeFileActions);
@@ -585,7 +585,7 @@ public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
     }
 
     private Pointer nativeSpawnAttributes(Collection<? extends SpawnAttribute> spawnAttributes) {
-        Pointer nativeSpawnAttributes = Memory.allocateDirect(getRuntime(), 128);
+        Pointer nativeSpawnAttributes = allocatePosixSpawnattr();
         ((UnixLibC) libc()).posix_spawnattr_init(nativeSpawnAttributes);
         for (SpawnAttribute action : spawnAttributes) {
             action.set(this, nativeSpawnAttributes);

--- a/src/main/java/jnr/posix/LinuxPOSIX.java
+++ b/src/main/java/jnr/posix/LinuxPOSIX.java
@@ -2,6 +2,7 @@ package jnr.posix;
 
 import jnr.constants.platform.Errno;
 import jnr.constants.platform.Sysconf;
+import jnr.ffi.Memory;
 import jnr.ffi.Pointer;
 import jnr.ffi.mapper.FromNativeContext;
 import jnr.posix.util.Platform;
@@ -42,6 +43,16 @@ final class LinuxPOSIX extends BaseNativePOSIX {
 
     public MsgHdr allocateMsgHdr() {
         return new LinuxMsgHdr(this);
+    }
+
+    @Override
+    public Pointer allocatePosixSpawnFileActions() {
+        return Memory.allocateDirect(getRuntime(), 80);
+    }
+
+    @Override
+    public Pointer allocatePosixSpawnattr() {
+        return Memory.allocateDirect(getRuntime(), 336);
     }
 
     public SocketMacros socketMacros() {

--- a/src/main/java/jnr/posix/MacOSPOSIX.java
+++ b/src/main/java/jnr/posix/MacOSPOSIX.java
@@ -25,6 +25,16 @@ final class MacOSPOSIX extends BaseNativePOSIX {
         return new MacOSMsgHdr(this);
     }
 
+    @Override
+    public Pointer allocatePosixSpawnFileActions() {
+        return Memory.allocateDirect(getRuntime(), 8);
+    }
+
+    @Override
+    public Pointer allocatePosixSpawnattr() {
+        return Memory.allocateDirect(getRuntime(), 8);
+    }
+
     public SocketMacros socketMacros() {
         return MacOSSocketMacros.INSTANCE;
     }

--- a/src/main/java/jnr/posix/NativePOSIX.java
+++ b/src/main/java/jnr/posix/NativePOSIX.java
@@ -1,5 +1,8 @@
 package jnr.posix;
 
+import jnr.ffi.Memory;
+import jnr.ffi.Pointer;
+
 /**
  *
  */
@@ -11,5 +14,13 @@ public abstract class NativePOSIX implements POSIX {
     }
 
     public abstract SocketMacros socketMacros();
+
+    public Pointer allocatePosixSpawnFileActions() {
+        return Memory.allocateDirect(getRuntime(), 128);
+    }
+
+    public Pointer allocatePosixSpawnattr() {
+        return Memory.allocateDirect(getRuntime(), 128);
+    }
 
 }


### PR DESCRIPTION
* Define a per-platform size since it is an opaque struct with
  unspecified members and needs to be checked with sizeof().
* Fixes #96.

This still uses the magic value of `128` bytes on other platforms.
Linux definition is probably unusual with the two big `sigset_t` in it:
```c
typedef struct
{
  short int __flags;
  pid_t __pgrp;
  sigset_t __sd;
  sigset_t __ss;
  struct sched_param __sp;
  int __policy;
  int __pad[16];
} posix_spawnattr_t;
```

OS X and Solaris just define them as a single `void*` pointer.

@nirvdrum Do you think this is good enough or should we run a sizeof() on all platforms to make sure no other than Linux exceeds 128 bytes?