### PR TITLE
Fix compatibility with AARCH64

### DIFF
--- a/src/main/java/jnr/posix/LinuxFileStat64.java
+++ b/src/main/java/jnr/posix/LinuxFileStat64.java
@@ -9,22 +9,22 @@ public final class LinuxFileStat64 extends BaseFileStat implements NanosecondFil
             super(runtime);
         }
 
-        public final Signed64 st_dev = new Signed64();
-        public final Signed64 st_ino = new Signed64();
-        public final Signed64 st_nlink = new Signed64();
-        public final Signed32 st_mode = new Signed32();
-        public final Signed32 st_uid = new Signed32();
-        public final Signed32 st_gid = new Signed32();
-        public final Signed64 st_rdev = new Signed64();
-        public final Signed64 st_size = new Signed64();
-        public final Signed64 st_blksize = new Signed64();
-        public final Signed64 st_blocks = new Signed64();
-        public final Signed64 st_atime = new Signed64();     // Time of last access (time_t)
-        public final Signed64 st_atimensec = new Signed64(); // Time of last access (nanoseconds)
-        public final Signed64 st_mtime = new Signed64();     // Last data modification time (time_t)
-        public final Signed64 st_mtimensec = new Signed64(); // Last data modification time (nanoseconds)
-        public final Signed64 st_ctime = new Signed64();     // Time of last status change (time_t)
-        public final Signed64 st_ctimensec = new Signed64(); // Time of last status change (nanoseconds)
+        public final dev_t st_dev = new dev_t();
+        public final ino_t st_ino = new ino_t();
+        public final nlink_t st_nlink = new nlink_t();
+        public final mode_t st_mode = new mode_t();
+        public final uid_t st_uid = new uid_t();
+        public final gid_t st_gid = new gid_t();
+        public final dev_t st_rdev = new dev_t();
+        public final size_t st_size = new size_t();
+        public final blksize_t st_blksize = new blksize_t();
+        public final blkcnt_t st_blocks = new blkcnt_t();
+        public final time_t st_atime = new time_t();     // Time of last access (time_t)
+        public final SignedLong st_atimensec = new SignedLong(); // Time of last access (nanoseconds)
+        public final time_t st_mtime = new time_t();     // Last data modification time (time_t)
+        public final SignedLong st_mtimensec = new SignedLong(); // Last data modification time (nanoseconds)
+        public final time_t st_ctime = new time_t();     // Time of last status change (time_t)
+        public final SignedLong st_ctimensec = new SignedLong(); // Time of last status change (nanoseconds)
         public final Signed64 __unused4 = new Signed64();
         public final Signed64 __unused5 = new Signed64();
         public final Signed64 __unused6 = new Signed64();
@@ -65,7 +65,7 @@ public final class LinuxFileStat64 extends BaseFileStat implements NanosecondFil
     }
 
     public int gid() {
-        return layout.st_gid.get(memory);
+        return (int) layout.st_gid.get(memory);
     }
 
     public long ino() {
@@ -73,7 +73,7 @@ public final class LinuxFileStat64 extends BaseFileStat implements NanosecondFil
     }
 
     public int mode() {
-        return layout.st_mode.get(memory);
+        return (int) layout.st_mode.get(memory);
     }
 
     public long mtime() {
@@ -97,6 +97,6 @@ public final class LinuxFileStat64 extends BaseFileStat implements NanosecondFil
     }
 
     public int uid() {
-        return layout.st_uid.get(memory);
+        return (int) layout.st_uid.get(memory);
     }
 }

--- a/src/main/java/jnr/posix/LinuxFileStatAARCH64.java
+++ b/src/main/java/jnr/posix/LinuxFileStatAARCH64.java
@@ -1,0 +1,101 @@
+package jnr.posix;
+
+import jnr.ffi.StructLayout;
+import jnr.posix.util.Platform;
+
+public final class LinuxFileStatAARCH64 extends BaseFileStat implements NanosecondFileStat {
+    public static final class Layout extends StructLayout {
+
+        public Layout(jnr.ffi.Runtime runtime) {
+            super(runtime);
+        }
+
+        public final dev_t st_dev = new dev_t();
+        public final ino_t st_ino = new ino_t();
+        public final mode_t st_mode = new mode_t();
+        public final nlink_t st_nlink = new nlink_t();
+        public final uid_t st_uid = new uid_t();
+        public final gid_t st_gid = new gid_t();
+        public final dev_t st_rdev = new dev_t();
+        public final size_t st_size = new size_t();
+        public final blksize_t st_blksize = new blksize_t();
+        public final blkcnt_t st_blocks = new blkcnt_t();
+        public final time_t st_atime = new time_t();             // Time of last access
+        public final SignedLong st_atimensec = new SignedLong(); // Time of last access (nanoseconds)
+        public final time_t st_mtime = new time_t();             // Last data modification time
+        public final SignedLong st_mtimensec = new SignedLong(); // Last data modification time (nanoseconds)
+        public final time_t st_ctime = new time_t();             // Time of last status change
+        public final SignedLong st_ctimensec = new SignedLong(); // Time of last status change (nanoseconds)
+        public final Signed64 __unused4 = new Signed64();
+    }
+
+    private static final Layout layout = new Layout(jnr.ffi.Runtime.getSystemRuntime());
+
+    public LinuxFileStatAARCH64(LinuxPOSIX posix) {
+        super(posix, layout);
+    }
+
+    public long atime() {
+        return layout.st_atime.get(memory);
+    }
+
+    public long aTimeNanoSecs() {
+        return layout.st_atimensec.get(memory);
+    }
+
+    public long blockSize() {
+        return layout.st_blksize.get(memory);
+    }
+
+    public long blocks() {
+        return layout.st_blocks.get(memory);
+    }
+
+    public long ctime() {
+        return layout.st_ctime.get(memory);
+    }
+
+    public long cTimeNanoSecs() {
+        return layout.st_ctimensec.get(memory);
+    }
+
+    public long dev() {
+        return layout.st_dev.get(memory);
+    }
+
+    public int gid() {
+        return (int) layout.st_gid.get(memory);
+    }
+
+    public long ino() {
+        return layout.st_ino.get(memory);
+    }
+
+    public int mode() {
+        return (int) layout.st_mode.get(memory);
+    }
+
+    public long mtime() {
+        return layout.st_mtime.get(memory);
+    }
+
+    public long mTimeNanoSecs() {
+        return layout.st_mtimensec.get(memory);
+    }
+
+    public int nlink() {
+        return (int) layout.st_nlink.get(memory);
+    }
+
+    public long rdev() {
+        return layout.st_rdev.get(memory);
+    }
+
+    public long st_size() {
+        return layout. st_size.get(memory);
+    }
+
+    public int uid() {
+        return (int) layout.st_uid.get(memory);
+    }
+}

--- a/src/main/java/jnr/posix/LinuxPOSIX.java
+++ b/src/main/java/jnr/posix/LinuxPOSIX.java
@@ -196,6 +196,7 @@ final class LinuxPOSIX extends BaseNativePOSIX implements Linux {
     static final public class Syscall {
         static final ABI _ABI_X86_32 = new ABI_X86_32();
         static final ABI _ABI_X86_64 = new ABI_X86_64();
+        static final ABI _ABI_AARCH64 = new ABI_AARCH64();
 
         public static ABI abi() {
             if ("x86_64".equals(Platform.ARCH)) {
@@ -204,6 +205,8 @@ final class LinuxPOSIX extends BaseNativePOSIX implements Linux {
                 }
             } else if ("i386".equals(Platform.ARCH)) {
                 return _ABI_X86_32;
+            } else if ("aarch64".equals(Platform.ARCH)) {
+                return _ABI_AARCH64;
             }
             return null;
         }
@@ -234,6 +237,18 @@ final class LinuxPOSIX extends BaseNativePOSIX implements Linux {
             @Override
             public int __NR_ioprio_get() {
                 return 252;
+            }
+        }
+
+        /** @see /usr/include/asm-generic/unistd.h */
+        final static class ABI_AARCH64 implements ABI {
+            @Override
+            public int __NR_ioprio_set() {
+                return 30;
+            }
+            @Override
+            public int __NR_ioprio_get() {
+                return 31 ;
             }
         }
     }

--- a/src/main/java/jnr/posix/LinuxPOSIX.java
+++ b/src/main/java/jnr/posix/LinuxPOSIX.java
@@ -37,7 +37,11 @@ final class LinuxPOSIX extends BaseNativePOSIX implements Linux {
         if (Platform.IS_32_BIT) {
             return new LinuxFileStat32(this);
         } else {
-            return new LinuxFileStat64(this);
+            if ("aarch64".equals(Platform.ARCH)) {
+                return new LinuxFileStatAARCH64(this);
+            } else {
+                return new LinuxFileStat64(this);
+            }
         }
     }
 


### PR DESCRIPTION
I added/,odified Linux `stat64` struct layouts according to `pahole` output:

`xtest.c`
```c
#define _LARGEFILE_SOURCE 1

#include <stdio.h>
#include <stdlib.h>
#include <time.h>

#include <sys/types.h>
#include <pwd.h>
#include <grp.h>
#include <sys/stat.h>
#include <unistd.h>

int main(int argc, char *argv[])
{
        struct stat sb;

        if (argc < 2)
        {
                fprintf(stderr, "Usage: %s: file ...\n", argv[0]);
                exit(EXIT_FAILURE);
        }

        for (int i = 1; i < argc; i++)
        {
                if (-1 == __xstat64(0, argv[i], &sb))
                {
                        perror("stat()");
                        exit(EXIT_FAILURE);
                }

                printf("%s:\n", argv[i]);
                printf("\tdev: %u\n", sb.st_dev);
                printf("\tinode: %u\n", sb.st_ino);
                printf("\tmode: %o\n", sb.st_mode);
                printf("\tlinks: %d\n", sb.st_nlink);
                printf("\towner: %u\n", sb.st_uid);
                printf("\tgroup: %u\n", sb.st_gid);
                printf("\trdev: %u\n", sb.st_rdev);
                printf("\tsize: %ld\n", sb.st_size);
                printf("\tblksize: %d\n", sb.st_blksize);
                printf("\tblkcnt: %ld\n", sb.st_blocks);
                printf("\tatime: %s", ctime(&sb.st_atim.tv_sec));
                printf("\tmtime: %s", ctime(&sb.st_mtim.tv_sec));
                printf("\tctime: %s", ctime(&sb.st_ctim.tv_sec));
                printf("\n");
        }

        return 0;
}
```

On `AARCH64`:

```
struct stat {
        __dev_t                    st_dev;               /*     0     8 */
        __ino_t                    st_ino;               /*     8     8 */
        __mode_t                   st_mode;              /*    16     4 */
        __nlink_t                  st_nlink;             /*    20     4 */
        __uid_t                    st_uid;               /*    24     4 */
        __gid_t                    st_gid;               /*    28     4 */
        __dev_t                    st_rdev;              /*    32     8 */
        __dev_t                    __pad1;               /*    40     8 */
        __off_t                    st_size;              /*    48     8 */
        __blksize_t                st_blksize;           /*    56     4 */
        int                        __pad2;               /*    60     4 */
        /* --- cacheline 1 boundary (64 bytes) --- */
        __blkcnt_t                 st_blocks;            /*    64     8 */
        struct timespec            st_atim;              /*    72    16 */
        struct timespec            st_mtim;              /*    88    16 */
        struct timespec            st_ctim;              /*   104    16 */
        int                        __glibc_reserved[2];  /*   120     8 */
        /* --- cacheline 2 boundary (128 bytes) --- */

        /* size: 128, cachelines: 2, members: 16 */
};
```

On `X86_64`:

```
struct stat {
	__dev_t                    st_dev;               /*     0     8 */
	__ino_t                    st_ino;               /*     8     8 */
	__nlink_t                  st_nlink;             /*    16     8 */
	__mode_t                   st_mode;              /*    24     4 */
	__uid_t                    st_uid;               /*    28     4 */
	__gid_t                    st_gid;               /*    32     4 */
	int                        __pad0;               /*    36     4 */
	__dev_t                    st_rdev;              /*    40     8 */
	__off_t                    st_size;              /*    48     8 */
	__blksize_t                st_blksize;           /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	__blkcnt_t                 st_blocks;            /*    64     8 */
	struct timespec            st_atim;              /*    72    16 */
	struct timespec            st_mtim;              /*    88    16 */
	struct timespec            st_ctim;              /*   104    16 */
	__syscall_slong_t          __glibc_reserved[3];  /*   120    24 */
	/* --- cacheline 2 boundary (128 bytes) was 16 bytes ago --- */

	/* size: 144, cachelines: 3, members: 15 */
	/* last cacheline: 16 bytes */
};
```

This PR fixes https://github.com/jruby/jruby/issues/4600 