### PR TITLE
Visibility of LinuxPOSIX changed to public

### DIFF
--- a/src/main/java/jnr/posix/LinuxPOSIX.java
+++ b/src/main/java/jnr/posix/LinuxPOSIX.java
@@ -9,7 +9,7 @@ import jnr.posix.util.Platform;
 
 import java.io.FileDescriptor;
 
-final class LinuxPOSIX extends BaseNativePOSIX implements Linux {
+public final class LinuxPOSIX extends BaseNativePOSIX implements Linux {
     private volatile boolean use_fxstat64 = true;
     private volatile boolean use_lxstat64 = true;
     private volatile boolean use_xstat64 = true;


### PR DESCRIPTION
Otherwise there is no way to access the ioprio functions.