### PR TITLE
change access and modification time precision in nanosecond with utimensat / futimens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>com.github.jnr</groupId>
   <artifactId>jnr-posix</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.42-SNAPSHOT</version>
+  <version>3.0.42</version>
   <name>jnr-posix</name>
   <description>
     Common cross-project/cross-platform POSIX APIs
@@ -79,12 +79,12 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.1.6-SNAPSHOT</version>
+      <version>2.1.7</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-constants</artifactId>
-      <version>0.9.10-SNAPSHOT</version>
+      <version>0.9.9</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>com.github.jnr</groupId>
   <artifactId>jnr-posix</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.42</version>
+  <version>3.0.43-SNAPSHOT</version>
   <name>jnr-posix</name>
   <description>
     Common cross-project/cross-platform POSIX APIs

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>com.github.jnr</groupId>
   <artifactId>jnr-posix</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.43-SNAPSHOT</version>
+  <version>3.0.43</version>
   <name>jnr-posix</name>
   <description>
     Common cross-project/cross-platform POSIX APIs

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>com.github.jnr</groupId>
   <artifactId>jnr-posix</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.43</version>
+  <version>3.0.44-SNAPSHOT</version>
   <name>jnr-posix</name>
   <description>
     Common cross-project/cross-platform POSIX APIs

--- a/src/main/java/jnr/posix/BaseNativePOSIX.java
+++ b/src/main/java/jnr/posix/BaseNativePOSIX.java
@@ -385,8 +385,8 @@ public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
     }
     
     public String readlink(String oldpath) throws IOException {
-        // TODO: this should not be hardcoded to 256 bytes
-        ByteBuffer buffer = ByteBuffer.allocate(256);
+        // TODO: this should not be hardcoded to 1024 bytes
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
         int result = libc().readlink(oldpath, buffer, buffer.capacity());
         
         if (result == -1) return null;

--- a/src/main/java/jnr/posix/BaseNativePOSIX.java
+++ b/src/main/java/jnr/posix/BaseNativePOSIX.java
@@ -393,7 +393,7 @@ public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
         
         buffer.position(0);
         buffer.limit(result);
-        return Charset.forName("ASCII").decode(buffer).toString();
+        return Charset.defaultCharset().decode(buffer).toString();
     }
 
     public int readlink(CharSequence path, byte[] buf, int bufsize) {

--- a/src/main/java/jnr/posix/BaseNativePOSIX.java
+++ b/src/main/java/jnr/posix/BaseNativePOSIX.java
@@ -450,6 +450,34 @@ public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
         return libc().lutimes(path, times);
     }
 
+    public int utimensat(int dirfd, String path, long[] atimespec, long[] mtimespec, int flag) {
+        Timespec[] times = null;
+        if (atimespec != null && mtimespec != null) {
+            times = Struct.arrayOf(getRuntime(), DefaultNativeTimespec.class, 2);
+            times[0].setTime(atimespec);
+            times[1].setTime(mtimespec);
+        }
+        return libc().utimensat(dirfd, path, times, flag);
+    }
+
+    public int utimensat(int dirfd, String path, Pointer times, int flag) {
+        return libc().utimensat(dirfd, path, times, flag);
+    }
+
+    public int futimens(int fd, long[] atimespec, long[] mtimespec) {
+        Timespec[] times = null;
+        if (atimespec != null && mtimespec != null) {
+            times = Struct.arrayOf(getRuntime(), DefaultNativeTimespec.class, 2);
+            times[0].setTime(atimespec);
+            times[1].setTime(mtimespec);
+        }
+        return libc().futimens(fd, times);
+    }
+
+    public int futimens(int fd, Pointer times) {
+        return libc().futimens(fd, times);
+    }
+
     public int fork() {
         return libc().fork();
     }

--- a/src/main/java/jnr/posix/CheckedPOSIX.java
+++ b/src/main/java/jnr/posix/CheckedPOSIX.java
@@ -369,6 +369,24 @@ final class CheckedPOSIX implements POSIX {
         try { return posix.lutimes(path, atimeval, mtimeval); } catch (UnsatisfiedLinkError ule) { return unimplementedInt(); }
     }
 
+    public int utimensat(int dirfd, String path, long[] atimespec, long[] mtimespec, int flag) {
+        try { return posix.utimensat(dirfd, path, atimespec, mtimespec, flag); } catch (UnsatisfiedLinkError ule) {
+            return unimplementedInt(); }
+    }
+
+    public int utimensat(int dirfd, String path, Pointer times, int flag) {
+        try { return posix.utimensat(dirfd, path, times, flag); } catch (UnsatisfiedLinkError ule) { return unimplementedInt(); }
+    }
+
+    public int futimens(int fd, long[] atimespec, long[] mtimespec) {
+        try { return posix.futimens(fd, atimespec, mtimespec); } catch (UnsatisfiedLinkError ule) {
+            return unimplementedInt(); }
+    }
+
+    public int futimens(int fd, Pointer times) {
+        try { return posix.futimens(fd, times); } catch (UnsatisfiedLinkError ule) { return unimplementedInt(); }
+    }
+
     public int wait(int[] status) {
         try { return posix.wait(status); } catch (UnsatisfiedLinkError ule) { return unimplementedInt(); }
     }

--- a/src/main/java/jnr/posix/DefaultNativeTimespec.java
+++ b/src/main/java/jnr/posix/DefaultNativeTimespec.java
@@ -1,0 +1,32 @@
+package jnr.posix;
+
+public final class DefaultNativeTimespec extends Timespec {
+    public final SignedLong tv_sec = new SignedLong();
+    public final SignedLong tv_nsec = new SignedLong();
+
+    public DefaultNativeTimespec(jnr.ffi.Runtime runtime) {
+        super(runtime);
+    }
+
+    public void setTime(long[] timespec) {
+        assert timespec.length == 2;
+        tv_sec.set(timespec[0]);
+        tv_nsec.set(timespec[1]);
+    }
+
+    public void sec(long sec) {
+        this.tv_sec.set(sec);
+    }
+
+    public void nsec(long usec) {
+        this.tv_nsec.set(usec);
+    }
+
+    public long sec() {
+        return tv_sec.get();
+    }
+
+    public long nsec() {
+        return tv_nsec.get();
+    }
+}

--- a/src/main/java/jnr/posix/JavaPOSIX.java
+++ b/src/main/java/jnr/posix/JavaPOSIX.java
@@ -461,6 +461,32 @@ final class JavaPOSIX implements POSIX {
         return unimplementedInt("lutimes");
     }
 
+    public int utimensat(int dirfd, String path, long[] atimespec, long[] mtimespec, int flag) {
+        long mtimeMillis;
+        if (mtimespec != null) {
+            assert mtimespec.length == 2;
+            mtimeMillis = (mtimespec[0] * 1000) + (mtimespec[1] / 1000000);
+        } else {
+            mtimeMillis = System.currentTimeMillis();
+        }
+        new File(path).setLastModified(mtimeMillis);
+        return 0;
+    }
+
+    public int utimensat(int dirfd, String path, Pointer times, int flag) {
+        return unimplementedInt("utimensat");
+    }
+
+    public int futimens(int fd, long[] atimespec, long[] mtimespec) {
+        handler.unimplementedError("futimens");
+        return unimplementedInt("futimens");
+    }
+
+    public int futimens(int fd, Pointer times) {
+        handler.unimplementedError("futimens");
+        return unimplementedInt("futimens");
+    }
+
     public int wait(int[] status) {
         return unimplementedInt("wait");
     }

--- a/src/main/java/jnr/posix/LazyPOSIX.java
+++ b/src/main/java/jnr/posix/LazyPOSIX.java
@@ -366,6 +366,22 @@ final class LazyPOSIX implements POSIX {
         return posix().lutimes(path, atimeval, mtimeval);
     }
 
+    public int utimensat(int dirfd, String path, long[] atimespec, long[] mtimespec, int flag) {
+        return posix().utimensat(dirfd, path, atimespec, mtimespec, flag);
+    }
+
+    public int utimensat(int dirfd, String path, Pointer times, int flag) {
+        return posix().utimensat(dirfd, path, times, flag);
+    }
+
+    public int futimens(int fd, long[] atimespec, long[] mtimespec) {
+        return posix().futimens(fd, atimespec, mtimespec);
+    }
+
+    public int futimens(int fd, Pointer times) {
+        return posix().futimens(fd, times);
+    }
+
     public int wait(int[] status) {
         return posix().wait(status);
     }

--- a/src/main/java/jnr/posix/LibC.java
+++ b/src/main/java/jnr/posix/LibC.java
@@ -116,6 +116,10 @@ public interface LibC {
     int utimes(String path, @In Pointer times);
     int futimes(int fd, @In Timeval[] times);
     int lutimes(CharSequence path, @In Timeval[] times);
+    int utimensat(int dirfd, String path, Timespec[] times, int flag);
+    int utimensat(int dirfd, String path, @In Pointer times, int flag);
+    int futimens(int fd, Timespec[] times);
+    int futimens(int fd, @In Pointer times);
     int fork();
     int waitpid(long pid, @Out int[] status, int options);
     int wait(@Out int[] status);

--- a/src/main/java/jnr/posix/POSIX.java
+++ b/src/main/java/jnr/posix/POSIX.java
@@ -1,6 +1,7 @@
 package jnr.posix;
 
 import jnr.constants.platform.Fcntl;
+import jnr.constants.platform.Signal;
 import jnr.constants.platform.Sysconf;
 import jnr.ffi.Pointer;
 import jnr.posix.util.ProcessMaker;
@@ -9,7 +10,6 @@ import java.io.FileDescriptor;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collection;
-import jnr.constants.platform.Signal;
 
 public interface POSIX {
     CharSequence crypt(CharSequence key, CharSequence salt);
@@ -120,6 +120,10 @@ public interface POSIX {
     int utimes(String path, Pointer times);
     int futimes(int fd, long[] atimeval, long[] mtimeval);
     int lutimes(String path, long[] atimeval, long[] mtimeval);
+    int utimensat(int dirfd, String path, long[] atimespec, long[] mtimespec, int flag);
+    int utimensat(int dirfd, String path, Pointer times, int flag);
+    int futimens(int fd, long[] atimespec, long[] mtimespec);
+    int futimens(int fd, Pointer times);
     int waitpid(int pid, int[] status, int flags);
     int waitpid(long pid, int[] status, int flags);
     int wait(int[] status);

--- a/src/main/java/jnr/posix/Timespec.java
+++ b/src/main/java/jnr/posix/Timespec.java
@@ -1,0 +1,14 @@
+package jnr.posix;
+
+import jnr.ffi.Struct;
+
+abstract public class Timespec extends Struct {
+    public Timespec(jnr.ffi.Runtime runtime) {
+        super(runtime);
+    }
+    abstract public void setTime(long[] timespec);
+    public abstract void sec(long sec);
+    public abstract void nsec(long nsec);
+    public abstract long sec();
+    public abstract long nsec();
+}

--- a/src/test/java/jnr/posix/FileTest.java
+++ b/src/test/java/jnr/posix/FileTest.java
@@ -482,7 +482,7 @@ public class FileTest {
     @Test
     public void readlinkTest() throws IOException {
         if (!Platform.IS_WINDOWS) {
-            File file = File.createTempFile("jnr-posix-readlink-test", "tmp");
+            File file = File.createTempFile("jnr-pøsix-réådlînk-tést", "tmp");
             File link = new File(file.getAbsolutePath() + "link");
 
             posix.symlink(file.getAbsolutePath(), link.getAbsolutePath());

--- a/src/test/java/jnr/posix/FileTest.java
+++ b/src/test/java/jnr/posix/FileTest.java
@@ -487,10 +487,13 @@ public class FileTest {
 
             posix.symlink(file.getAbsolutePath(), link.getAbsolutePath());
 
-            byte[] buffer = new byte[file.getAbsolutePath().length()];
-            assertEquals(buffer.length, posix.readlink(link.getAbsolutePath(), buffer, buffer.length));
+            byte[] fileBytes = file.getAbsolutePath().getBytes();
+            int fileLength = fileBytes.length;
+            byte[] buffer = new byte[fileLength];
 
-            assertArrayEquals(buffer, file.getAbsolutePath().getBytes());
+            assertEquals(fileLength, posix.readlink(link.getAbsolutePath(), buffer, buffer.length));
+
+            assertArrayEquals(fileBytes, buffer);
 
             link.delete();
             file.delete();
@@ -500,13 +503,16 @@ public class FileTest {
     @Test
     public void readlinkByteBufferTest() throws IOException {
         if (!Platform.IS_WINDOWS) {
-            File file = File.createTempFile("jnr-posix-readlink-test", "tmp");
+            File file = File.createTempFile("jnr-pøsix-réådlînk-tést", "tmp");
             File link = new File(file.getAbsolutePath() + "link");
 
             posix.symlink(file.getAbsolutePath(), link.getAbsolutePath());
 
-            ByteBuffer buffer = ByteBuffer.allocate(file.getAbsolutePath().length());
-            assertEquals(buffer.capacity(), posix.readlink(link.getAbsolutePath(), buffer, buffer.capacity()));
+            byte[] fileBytes = file.getAbsolutePath().getBytes();
+            int fileLength = fileBytes.length;
+            ByteBuffer buffer = ByteBuffer.allocate(fileLength);
+
+            assertEquals(fileLength, posix.readlink(link.getAbsolutePath(), buffer, buffer.capacity()));
 
             assertArrayEquals(buffer.array(), file.getAbsolutePath().getBytes());
 
@@ -518,18 +524,21 @@ public class FileTest {
     @Test
     public void readlinkPointerTest() throws IOException {
         if (!Platform.IS_WINDOWS) {
-            File file = File.createTempFile("jnr-posix-readlink-test", "tmp");
+            File file = File.createTempFile("jnr-pøsix-réådlînk-tést", "tmp");
             File link = new File(file.getAbsolutePath() + "link");
 
             int bufSize = 1024;
-            int filenameLength = file.getAbsolutePath().length();
 
             Pointer buffer = jnr.ffi.Runtime.getSystemRuntime().getMemoryManager().allocateDirect(bufSize);
+
             posix.symlink(file.getAbsolutePath(), link.getAbsolutePath());
+            
+            byte[] fileBytes = file.getAbsolutePath().getBytes();
+            int fileLength = fileBytes.length;
 
-            assertEquals(filenameLength, posix.readlink(link.getAbsolutePath(), buffer, bufSize));
+            assertEquals(fileLength, posix.readlink(link.getAbsolutePath(), buffer, bufSize));
 
-            assertEquals(buffer.getString(0, filenameLength, Charset.defaultCharset()), file.getAbsolutePath());
+            assertEquals(file.getAbsolutePath(), buffer.getString(0, fileLength, Charset.defaultCharset()));
 
             link.delete();
             file.delete();

--- a/src/test/java/jnr/posix/windows/WindowsFileTest.java
+++ b/src/test/java/jnr/posix/windows/WindowsFileTest.java
@@ -221,4 +221,31 @@ public class WindowsFileTest {
         int result = ((WindowsPOSIX) posix).findFirstFile("sdjfhjfsdfhdsdfhsdj", stat);
         assertTrue(result < 0);
     }
+
+    @Test
+    public void utimensatWindows() throws Throwable {
+        File file = File.createTempFile("utimensat", null);
+        FileStat fileStat = posix.stat(file.getPath());
+
+        long atimeSeconds = fileStat.atime()+1;
+        long mtimeSeconds = fileStat.mtime()-1;
+
+        // Windows precision is 100 ns
+        long atimeNanoSeconds = 123456700;
+        long mtimeNanoSeconds = 987654300;
+
+        // dirfd is ignored when passing an absolute path
+        // flag can be used to update symlinks
+        posix.utimensat(0,
+                file.getAbsolutePath(),
+                new long[] {atimeSeconds, atimeNanoSeconds},
+                new long[] {mtimeSeconds, mtimeNanoSeconds},
+                0);
+
+        fileStat = posix.stat(file.getPath());
+        assertEquals("access time should be updated", atimeSeconds, fileStat.atime());
+        assertEquals("modification time should be updated", mtimeSeconds, fileStat.mtime());
+
+        file.delete();
+    }
 }


### PR DESCRIPTION
This is a required change to fix https://github.com/jruby/jruby/issues/4710

It adds support to call libc [utimensat / futimens](http://man7.org/linux/man-pages/man2/utimensat.2.html) which provide nanosecond precision when updating access time / modification time of a file.