### PR TITLE
fix AIX timeval

### DIFF
--- a/src/main/java/jnr/posix/AixFlock.java
+++ b/src/main/java/jnr/posix/AixFlock.java
@@ -1,0 +1,55 @@
+package jnr.posix;
+
+public final class AixFlock extends Flock {
+    public final Signed16 l_type = new Signed16();
+    public final Signed16 l_whence = new Signed16();
+    public final Unsigned32 l_sysid = new Unsigned32();
+    public final Signed32 l_pid = new Signed32();
+    public final Signed32 l_vfs = new Signed32();
+    public final SignedLong l_start = new SignedLong();
+    public final SignedLong l_len = new SignedLong();
+
+    public AixFlock(jnr.ffi.Runtime runtime) {
+        super(runtime);
+    }
+
+    public void type(short type) {
+        this.l_type.set(type);
+    }
+
+    public void whence(short whence) {
+        this.l_whence.set(whence);
+    }
+
+    public void start(long start) {
+        this.l_start.set(start);
+    }
+
+    public void len(long len) {
+        this.l_len.set(len);
+    }
+
+    public void pid(int pid) {
+        this.l_pid.set(pid);
+    }
+
+    public short type() {
+        return this.l_type.get();
+    }
+
+    public short whence() {
+        return this.l_whence.get();
+    }
+
+    public long start() {
+        return this.l_start.get();
+    }
+
+    public long len() {
+        return this.l_len.get();
+    }
+
+    public int pid() {
+        return this.l_pid.get();
+    }
+}

--- a/src/main/java/jnr/posix/AixPOSIX.java
+++ b/src/main/java/jnr/posix/AixPOSIX.java
@@ -80,4 +80,7 @@ final class AixPOSIX extends BaseNativePOSIX {
     public Pointer allocatePosixSpawnattr() {
         return Memory.allocateDirect(getRuntime(), 60);
     }
+
+    @Override
+    public Timeval allocateTimeval() { return new AixTimeval(getRuntime()); }
 }

--- a/src/main/java/jnr/posix/AixPOSIX.java
+++ b/src/main/java/jnr/posix/AixPOSIX.java
@@ -32,6 +32,7 @@
 package jnr.posix;
 
 import jnr.constants.platform.Sysconf;
+import jnr.constants.platform.Fcntl;
 import jnr.ffi.Memory;
 import jnr.ffi.Pointer;
 import jnr.ffi.mapper.FromNativeContext;
@@ -40,6 +41,22 @@ import jnr.posix.util.MethodName;
 import java.io.FileDescriptor;
 
 final class AixPOSIX extends BaseNativePOSIX {
+    // These should probably be put into jnr-constants instead eventually, but
+    // they're here for now as a one-off to work around AIX flock issues
+    private enum FlockFlags {
+        LOCK_SH(1),
+        LOCK_EX(2),
+        LOCK_NB(4),
+        LOCK_UN(8);
+        private final int value;
+        FlockFlags(int value) {
+            this.value = value;
+        }
+        public final int intValue() {
+            return value;
+        }
+    }
+
     AixPOSIX(LibCProvider libc, POSIXHandler handler) {
         super(libc, handler);
     }
@@ -81,6 +98,41 @@ final class AixPOSIX extends BaseNativePOSIX {
         return Memory.allocateDirect(getRuntime(), 60);
     }
 
+    // AIX flock lives in libbsd instead of libc.  AIX flock locks fully
+    // interact with fcntl locks, so we can implement flock in terms of fcntl,
+    // which is what we do here to avoid having to pull in that lib.
+    @Override
+    public int flock(int fd, int operation) {
+        int cmd = Fcntl.F_SETLKW.intValue();
+        short type = 0;
+
+        // Map the flock call flags to a fcntl flock type flag
+        if ((operation & FlockFlags.LOCK_SH.intValue()) != 0) {
+            type = (short)Fcntl.F_RDLCK.intValue();
+        } else if ((operation & FlockFlags.LOCK_EX.intValue()) != 0) {
+            type = (short)Fcntl.F_WRLCK.intValue();
+        } else if ((operation & FlockFlags.LOCK_UN.intValue()) != 0) {
+            type = (short)Fcntl.F_UNLCK.intValue();
+        }
+
+        // Switch to the fcntl non-blocking command
+        if ((operation & FlockFlags.LOCK_NB.intValue()) != 0) {
+            cmd = Fcntl.F_SETLK.intValue();
+        }
+
+        Flock flock = allocateFlock();
+        flock.type(type);
+        flock.whence((short)0);
+        flock.start(0);
+        flock.len(0);
+        return libc().fcntl(fd, cmd, flock);
+    }
+
     @Override
     public Timeval allocateTimeval() { return new AixTimeval(getRuntime()); }
+
+    // This isn't an override yet, because Flock would have to be implemented
+    // for all platforms, or at least with a DefaultNative implementation.  This
+    // is fine for now, because only AIX uses the flock structure
+    public Flock allocateFlock() { return new AixFlock(getRuntime()); }
 }

--- a/src/main/java/jnr/posix/AixTimeval.java
+++ b/src/main/java/jnr/posix/AixTimeval.java
@@ -1,0 +1,32 @@
+package jnr.posix;
+
+public final class AixTimeval extends Timeval {
+    public final SignedLong tv_sec = new SignedLong();
+    public final Signed32 tv_usec = new Signed32();
+
+    public AixTimeval(jnr.ffi.Runtime runtime) {
+        super(runtime);
+    }
+
+    public void setTime(long[] timeval) {
+        assert timeval.length == 2;
+        tv_sec.set(timeval[0]);
+        tv_usec.set((int)timeval[1]);
+    }
+
+    public void sec(long sec) {
+        this.tv_sec.set(sec);
+    }
+
+    public void usec(long usec) {
+        this.tv_usec.set((int)usec);
+    }
+
+    public long sec() {
+        return tv_sec.get();
+    }
+
+    public long usec() {
+        return tv_usec.get();
+    }
+}

--- a/src/main/java/jnr/posix/Flock.java
+++ b/src/main/java/jnr/posix/Flock.java
@@ -1,0 +1,20 @@
+package jnr.posix;
+
+import jnr.ffi.Struct;
+
+abstract public class Flock extends Struct {
+    public Flock(jnr.ffi.Runtime runtime) {
+        super(runtime);
+    }
+    public abstract void type(short type);
+    public abstract void whence(short whence);
+    public abstract void start(long start);
+    public abstract void len(long len);
+    public abstract void pid(int pid);
+
+    public abstract short type();
+    public abstract short whence();
+    public abstract long start();
+    public abstract long len();
+    public abstract int pid();
+}

--- a/src/main/java/jnr/posix/LibC.java
+++ b/src/main/java/jnr/posix/LibC.java
@@ -84,6 +84,7 @@ public interface LibC {
     int dup(int fd);
     int dup2(int oldFd, int newFd);
 
+    int fcntl(int fd, int fnctl, Flock arg);
     int fcntl(int fd, int fnctl, Pointer arg);
     int fcntl(int fd, int fnctl);
     int fcntl(int fd, int fnctl, int arg);


### PR DESCRIPTION
AIX suseconds_t is 32-bit, not 64.  The default POSIX implementation was
pulling in garbage in the microsecond field.

edit: I've also wrapped in a workaround for AIX flock, which wasn't working before, as described in the commit message:

>     AIX flock lives in libbsd instead of libc, so it couldn't work the way
>     it does in other platforms (which usually expect it in libc).  This is a
>     quick workaround that uses fcntl locks instead.  This would not be
>     sufficient in Linux, because flock and fcntl locks do not interact, but
>     they do in AIX, so this wrapper works as a platform-specific shim.
>     
>     As well as the workaround, this patch also implements the standard
>     'struct flock' POSIX interface and the AIX specific structure, which
>     might be generally useful elsewhere, though platform specific structures
>     will have to be defined for other platforms that might want to use it.

So, this also closes #118