### PR TITLE
Isolate the crypt function into its own library.

### DIFF
--- a/src/main/java/jnr/posix/BaseNativePOSIX.java
+++ b/src/main/java/jnr/posix/BaseNativePOSIX.java
@@ -26,6 +26,7 @@ import jnr.constants.platform.Signal;
 
 public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
     private final LibC libc;
+    private final Crypt crypt;
     
     protected final POSIXHandler handler;
     protected final JavaLibCHelper helper;
@@ -35,6 +36,7 @@ public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
     protected BaseNativePOSIX(LibCProvider libcProvider, POSIXHandler handler) {
         this.handler = handler;
         this.libc = libcProvider.getLibC();
+        this.crypt = libcProvider.getCrypt();
         this.helper = new JavaLibCHelper(handler);
     }
 
@@ -48,6 +50,10 @@ public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
 
     public final LibC libc() {
         return libc;
+    }
+
+    public final Crypt crypt() {
+        return crypt;
     }
 
     POSIXHandler handler() {
@@ -81,11 +87,23 @@ public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
     }
 
     public CharSequence crypt(CharSequence key, CharSequence salt) {
-        return libc().crypt(key, salt);
+        Crypt crypt = crypt();
+
+        if (crypt == null) {
+            return JavaLibCHelper.crypt(key, salt);
+        }
+
+        return crypt.crypt(key, salt);
     }
 
     public byte[] crypt(byte[] key, byte[] salt) {
-        Pointer ptr = libc().crypt(key, salt);
+        Crypt crypt = crypt();
+
+        if (crypt == null) {
+            return JavaLibCHelper.crypt(key, salt);
+        }
+
+        Pointer ptr = crypt().crypt(key, salt);
         if (ptr == null) return null;
         int end = ptr.indexOf(0, (byte)0);
         byte[] bytes = new byte[end + 1];

--- a/src/main/java/jnr/posix/Crypt.java
+++ b/src/main/java/jnr/posix/Crypt.java
@@ -1,0 +1,8 @@
+package jnr.posix;
+
+import jnr.ffi.Pointer;
+
+public interface Crypt {
+    CharSequence crypt(CharSequence key, CharSequence salt);
+    Pointer crypt(byte[] key, byte[] salt);
+}

--- a/src/main/java/jnr/posix/LibC.java
+++ b/src/main/java/jnr/posix/LibC.java
@@ -38,8 +38,6 @@ import jnr.ffi.types.*;
 import java.nio.ByteBuffer;
 
 public interface LibC {
-    CharSequence crypt(CharSequence key, CharSequence salt);
-    Pointer crypt(byte[] key, byte[] salt);
     int chmod(CharSequence filename, int mode);
     int fchmod(int fd, int mode);
     int chown(CharSequence filename, int user, int group);

--- a/src/main/java/jnr/posix/LibCProvider.java
+++ b/src/main/java/jnr/posix/LibCProvider.java
@@ -3,4 +3,5 @@ package jnr.posix;
 
 public interface LibCProvider {
     public LibC getLibC();
+    public Crypt getCrypt();
 }


### PR DESCRIPTION
See jruby/jruby#5447

musl-libc based Linux distributions do not ship the crypt library,
and since jnr-ffi is set up to error if any requested libraries
fail to load, this prevents native access from loading properly.
For purposes of jruby/jruby#5447, it appears the loading process
succeeds but the crypt function is not bound correctly and
segfaults. This logic tries the various possible names for the
crypt library in turn, eventually trying libc and letting it hard
error if the crypt function cannot be found and bound.