### PR TITLE
Initial DragonFly BSD support

### DIFF
--- a/src/main/java/jnr/posix/DragonFlyFileStat.java
+++ b/src/main/java/jnr/posix/DragonFlyFileStat.java
@@ -1,0 +1,141 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/cpl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ *
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the CPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the CPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+/**
+ * $Id: $
+ */
+
+package jnr.posix;
+
+import jnr.ffi.StructLayout;
+
+public final class DragonFlyFileStat extends BaseFileStat implements NanosecondFileStat {
+    private static final class Layout extends StructLayout {
+
+        private Layout(jnr.ffi.Runtime runtime) {
+            super(runtime);
+        }
+
+        public final class time_t extends SignedLong {}
+        public final class dev_t extends Unsigned32 {}
+
+        public final Signed64    st_ino = new Signed64();
+        public final Signed32    st_nlink = new Signed32();
+        public final dev_t       st_dev = new dev_t();
+        public final Unsigned16  st_mode = new Unsigned16();
+        public final Unsigned16  st_padding1 = new Unsigned16();
+        public final Signed32    st_uid = new Signed32();
+        public final Signed32    st_gid = new Signed32();
+        public final dev_t       st_rdev = new dev_t();
+        public final time_t      st_atim = new time_t();
+        public final time_t      st_atimnsec = new time_t();
+        public final time_t      st_mtim = new time_t();
+        public final time_t      st_mtimnsec = new time_t();
+        public final time_t      st_ctim = new time_t();
+        public final time_t      st_ctimnsec = new time_t();
+        public final Signed32    st_size = new Signed32();
+        public final Signed32    st_blocks = new Signed32();
+        public final Signed32    st_blksize = new Signed32();
+        public final Signed32    st_flags = new Signed32();
+        public final Signed32    st_gen = new Signed32();
+        public final Signed32    st_lspare = new Signed32();
+        public final Signed64    st_qspare1 = new Signed64();
+        public final Signed64    st_qspare2 = new Signed64();
+    }
+    private static final Layout layout = new Layout(jnr.ffi.Runtime.getSystemRuntime());
+
+    public DragonFlyFileStat(NativePOSIX posix) {
+        super(posix, layout);
+    }
+
+    public long atime() {
+        return layout.st_atim.get(memory);
+    }
+
+    public long blocks() {
+        return layout.st_blocks.get(memory);
+    }
+
+    public long blockSize() {
+        return layout.st_blksize.get(memory);
+    }
+
+    public long ctime() {
+        return layout.st_ctim.get(memory);
+    }
+
+    public long dev() {
+        return layout.st_dev.get(memory);
+    }
+
+    public int gid() {
+        return layout.st_gid.get(memory);
+    }
+
+    public long ino() {
+        return layout.st_ino.get(memory);
+    }
+
+    public int mode() {
+        return layout.st_mode.get(memory) & 0xffff;
+    }
+
+    public long mtime() {
+        return layout.st_mtim.get(memory);
+    }
+
+    public int nlink() {
+        return layout.st_nlink.get(memory);
+    }
+
+    public long rdev() {
+        return layout.st_rdev.get(memory);
+    }
+
+    public long st_size() {
+        return layout.st_size.get(memory);
+    }
+
+    public int uid() {
+        return layout.st_uid.get(memory);
+    }
+
+    @Override
+    public long aTimeNanoSecs() {
+        return layout.st_atimnsec.get(memory);
+    }
+
+    @Override
+    public long cTimeNanoSecs() {
+        return layout.st_ctimnsec.get(memory);
+    }
+
+    @Override
+    public long mTimeNanoSecs() {
+        return layout.st_mtimnsec.get(memory);
+    }
+}

--- a/src/main/java/jnr/posix/DragonFlyPOSIX.java
+++ b/src/main/java/jnr/posix/DragonFlyPOSIX.java
@@ -1,0 +1,81 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/cpl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ *
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the CPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the CPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+/**
+ * $Id: $
+ */
+
+package jnr.posix;
+
+import jnr.constants.platform.Sysconf;
+import jnr.ffi.Memory;
+import jnr.ffi.mapper.FromNativeContext;
+import jnr.ffi.Pointer;
+import jnr.posix.util.MethodName;
+
+final class DragonFlyPOSIX extends BaseNativePOSIX {
+    DragonFlyPOSIX(LibCProvider libc, POSIXHandler handler) {
+        super(libc, handler);
+    }
+
+    public FileStat allocateStat() {
+        return new DragonFlyFileStat(this);
+    }
+
+    public MsgHdr allocateMsgHdr() {
+        handler.unimplementedError(MethodName.getCallerMethodName());
+        return null;
+    }
+
+    public SocketMacros socketMacros() {
+        handler.unimplementedError(MethodName.getCallerMethodName());
+        return null;
+    }
+
+    public long sysconf(Sysconf name) {
+        return libc().sysconf(name);
+    }
+
+    public Times times() {
+        return NativeTimes.times(this);
+    }
+
+
+    public static final PointerConverter PASSWD = new PointerConverter() {
+        public Object fromNative(Object arg, FromNativeContext ctx) {
+            return arg != null ? new DragonFlyPasswd((Pointer) arg) : null;
+        }
+    };
+
+    public Pointer allocatePosixSpawnFileActions() {
+        return Memory.allocateDirect(getRuntime(), 8);
+    }
+
+    public Pointer allocatePosixSpawnattr() {
+        return Memory.allocateDirect(getRuntime(), 8);
+    }
+}

--- a/src/main/java/jnr/posix/DragonFlyPasswd.java
+++ b/src/main/java/jnr/posix/DragonFlyPasswd.java
@@ -1,0 +1,101 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/cpl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ *
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the CPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the CPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+/**
+ * $Id: $
+ */
+
+package jnr.posix;
+
+
+import jnr.ffi.StructLayout;
+
+public class DragonFlyPasswd extends NativePasswd implements Passwd {
+    private static final class Layout extends StructLayout {
+
+        private Layout(jnr.ffi.Runtime runtime) {
+            super(runtime);
+        }
+
+        public final UTF8StringRef pw_name = new UTF8StringRef();   // user name
+        public final UTF8StringRef pw_passwd = new UTF8StringRef(); // password (encrypted)
+        public final Signed32 pw_uid = new Signed32();       // user id
+        public final Signed32 pw_gid = new Signed32();       // user id
+        public final SignedLong pw_change = new SignedLong();// password change time
+        public final UTF8StringRef pw_class = new UTF8StringRef();  // user access class
+        public final UTF8StringRef pw_gecos = new UTF8StringRef();  // login info
+        public final UTF8StringRef pw_dir = new UTF8StringRef();    // home directory
+        public final UTF8StringRef pw_shell = new UTF8StringRef();  // default shell
+        public final SignedLong pw_expire = new SignedLong();    // account expiration
+        public final Signed32 pw_fields = new Signed32();    // internal: fields filled in
+    }
+    private static final Layout layout = new Layout(jnr.ffi.Runtime.getSystemRuntime());
+
+    DragonFlyPasswd(jnr.ffi.Pointer memory) {
+        super(memory);
+    }
+
+    public java.lang.String getAccessClass() {
+        return layout.pw_class.get(memory);
+    }
+
+    public java.lang.String getGECOS() {
+        return layout.pw_gecos.get(memory);
+    }
+
+    public long getGID() {
+        return layout.pw_gid.get(memory);
+    }
+
+    public java.lang.String getHome() {
+        return layout.pw_dir.get(memory);
+    }
+
+    public java.lang.String getLoginName() {
+        return layout.pw_name.get(memory);
+    }
+
+    public int getPasswdChangeTime() {
+        return layout.pw_change.intValue(memory);
+    }
+
+    public java.lang.String getPassword() {
+        return layout.pw_passwd.get(memory);
+    }
+
+    public java.lang.String getShell() {
+        return layout.pw_shell.get(memory);
+    }
+
+    public long getUID() {
+        return layout.pw_uid.get(memory);
+    }
+
+    public int getExpire() {
+        return layout.pw_expire.intValue(memory);
+    }
+}

--- a/src/main/java/jnr/posix/POSIXFactory.java
+++ b/src/main/java/jnr/posix/POSIXFactory.java
@@ -125,6 +125,9 @@ public class POSIXFactory {
 
             case FREEBSD:
                 return loadFreeBSDPOSIX(handler);
+
+            case DRAGONFLY:
+                return loadDragonFlyPOSIX(handler);
             
             case OPENBSD:
                 return loadOpenBSDPOSIX(handler);
@@ -158,6 +161,10 @@ public class POSIXFactory {
         return new FreeBSDPOSIX(DefaultLibCProvider.INSTANCE, handler);
     }
 
+    public static POSIX loadDragonFlyPOSIX(POSIXHandler handler) {
+        return new DragonFlyPOSIX(DefaultLibCProvider.INSTANCE, handler);
+    }
+
     public static POSIX loadOpenBSDPOSIX(POSIXHandler handler) {
         return new OpenBSDPOSIX(DefaultLibCProvider.INSTANCE, handler);
     }
@@ -178,6 +185,7 @@ public class POSIXFactory {
             case SOLARIS:
                 return new String[] { "socket", "nsl", STANDARD_C_LIBRARY_NAME};
 
+            case DRAGONFLY:
             case FREEBSD:
             case NETBSD:
                 return new String[] {STANDARD_C_LIBRARY_NAME};

--- a/src/main/java/jnr/posix/POSIXTypeMapper.java
+++ b/src/main/java/jnr/posix/POSIXTypeMapper.java
@@ -20,6 +20,8 @@ final class POSIXTypeMapper implements TypeMapper {
                 return SolarisPOSIX.PASSWD;
             } else if (Platform.IS_FREEBSD) {
                 return FreeBSDPOSIX.PASSWD;
+            } else if (Platform.IS_DRAGONFLY) {
+                return DragonFlyPOSIX.PASSWD;
             } else if (Platform.IS_OPENBSD) {
                 return OpenBSDPOSIX.PASSWD;
             } else if (Platform.IS_WINDOWS) {

--- a/src/main/java/jnr/posix/util/Platform.java
+++ b/src/main/java/jnr/posix/util/Platform.java
@@ -51,6 +51,7 @@ public class Platform {
     private static final String MAC_OS = "mac os";
     private static final String DARWIN = "darwin";
     private static final String FREEBSD = "freebsd";
+    private static final String DRAGONFLY = "dragonfly";
     private static final String OPENBSD = "openbsd";
     private static final String LINUX = "linux";
     private static final String SOLARIS = "sunos";
@@ -67,10 +68,11 @@ public class Platform {
     public static final boolean IS_WINDOWS_7 = IS_WINDOWS && OS_NAME_LC.indexOf(WINDOWS_7) > -1;
     public static final boolean IS_MAC = OS_NAME_LC.startsWith(MAC_OS) || OS_NAME_LC.startsWith(DARWIN);
     public static final boolean IS_FREEBSD = OS_NAME_LC.startsWith(FREEBSD);
+    public static final boolean IS_DRAGONFLY = OS_NAME_LC.startsWith(DRAGONFLY);
     public static final boolean IS_OPENBSD = OS_NAME_LC.startsWith(OPENBSD);
     public static final boolean IS_LINUX = OS_NAME_LC.startsWith(LINUX);   
     public static final boolean IS_SOLARIS = OS_NAME_LC.startsWith(SOLARIS);
-    public static final boolean IS_BSD = IS_MAC || IS_FREEBSD || IS_OPENBSD;
+    public static final boolean IS_BSD = IS_MAC || IS_FREEBSD || IS_OPENBSD || IS_DRAGONFLY;
     
     public static final String envCommand() {
         if (IS_WINDOWS) {


### PR DESCRIPTION
This is a patch for the initial support of DragonFly BSD.

Please note it requires (https://github.com/jnr/jnr-ffi/pull/184) first, otherwise it won't even compile (due to the enum not returning DRAGONFLY).

Also note that not all the test are passed, not sure why. Any pointer is welcome. Building it with:

    mvn -Dmaven.test.skip=true package

creates the packages.

Test results

    -------------------------------------------------------
     T E S T S
    -------------------------------------------------------
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    RRuunnnniinngg  jjnnrr..ppoossiixx..DFTialbelSetSaitzTeeTsets
    Successfully loaded native POSIX impl.
    t
    Successfully loaded native POSIX impl.
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec - in jnr.posix.DTableSizeTest
    Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 sec - in jnr.posix.FileStatTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.JavaFileStatTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 sec - in jnr.posix.JavaFileStatTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.util.PlatformTest
    Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 sec - in jnr.posix.util.PlatformTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.util.DefaultPOSIXHandlerTest
    Running jnr.posix.FileTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.959 sec - in jnr.posix.util.DefaultPOSIXHandlerTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Successfully loaded native POSIX impl.
    Running jnr.posix.POSIXFactoryTest
    Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.716 sec - in jnr.posix.POSIXFactoryTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.LinuxPOSIXTest
    Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 sec - in jnr.posix.LinuxPOSIXTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.JavaPOSIXTest
    Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.146 sec - in jnr.posix.JavaPOSIXTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.GroupTest
    Successfully loaded native POSIX impl.
    Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.747 sec - in jnr.posix.GroupTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.IOTest
    Successfully loaded native POSIX impl.
    Tests run: 5, Failures: 4, Errors: 0, Skipped: 0, Time elapsed: 0.665 sec <<< FAILURE! - in jnr.posix.IOTest
    testSendRecvMsg_NoControl(jnr.posix.IOTest)  Time elapsed: 0.636 sec  <<< FAILURE!
    java.lang.AssertionError: null
            at org.junit.Assert.fail(Assert.java:86)
            at org.junit.Assert.assertTrue(Assert.java:41)
            at org.junit.Assert.assertTrue(Assert.java:52)
            at jnr.posix.IOTest.testSendRecvMsg_NoControl(IOTest.java:111)
    testSocketPair(jnr.posix.IOTest)  Time elapsed: 0 sec  <<< FAILURE!
    java.lang.AssertionError: null
            at org.junit.Assert.fail(Assert.java:86)
            at org.junit.Assert.assertTrue(Assert.java:41)
            at org.junit.Assert.assertTrue(Assert.java:52)
            at jnr.posix.IOTest.testSocketPair(IOTest.java:80)

    testSendRecvMsg_WithControl(jnr.posix.IOTest)  Time elapsed: 0.001 sec  <<< FAILURE!
        java.lang.AssertionError: null
            at org.junit.Assert.fail(Assert.java:86)
            at org.junit.Assert.assertTrue(Assert.java:41)
            at org.junit.Assert.assertTrue(Assert.java:52)
            at jnr.posix.IOTest.testSendRecvMsg_WithControl(IOTest.java:159)
    
    testOpenReadWrite(jnr.posix.IOTest)  Time elapsed: 0.001 sec  <<< FAILURE!
    java.lang.AssertionError: expected:<5> but was:<-1>
            at org.junit.Assert.fail(Assert.java:88)
            at org.junit.Assert.failNotEquals(Assert.java:743)
            at org.junit.Assert.assertEquals(Assert.java:118)
            at org.junit.Assert.assertEquals(Assert.java:555)
            at org.junit.Assert.assertEquals(Assert.java:542)
            at jnr.posix.IOTest.testOpenReadWrite(IOTest.java:34)
    
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.SpawnTest
    Tests run: 32, Failures: 7, Errors: 2, Skipped: 0, Time elapsed: 5.414 sec <<< FAILURE! - in jnr.posix.FileTest
    dup2Test(jnr.posix.FileTest)  Time elapsed: 1.238 sec  <<< ERROR!
    java.io.IOException: Bad file descriptor
            at java.io.FileOutputStream.writeBytes(Native Method)
            at java.io.FileOutputStream.write(FileOutputStream.java:313)
            at jnr.posix.FileTest.dup2Test(FileTest.java:275)
    
    utimensatRelativePath(jnr.posix.FileTest)  Time elapsed: 0.069 sec  <<< FAILURE!
    java.lang.AssertionError: Access timestamp should be updated expected:<941406988> but was:<941406984>
            at org.junit.Assert.fail(Assert.java:88)
            at org.junit.Assert.failNotEquals(Assert.java:743)
            at org.junit.Assert.assertEquals(Assert.java:118)
            at org.junit.Assert.assertEquals(Assert.java:555)
            at jnr.posix.FileTest.assertStatNanoSecond(FileTest.java:661)
            at jnr.posix.FileTest.utimensat(FileTest.java:656)
            at jnr.posix.FileTest.utimensatRelativePath(FileTest.java:124)
    
    utimesTest(jnr.posix.FileTest)  Time elapsed: 0.001 sec  <<< FAILURE!
    java.lang.AssertionError: atime seconds failed expected:<800> but was:<900>
            at org.junit.Assert.fail(Assert.java:88)
            at org.junit.Assert.failNotEquals(Assert.java:743)
            at org.junit.Assert.assertEquals(Assert.java:118)
            at org.junit.Assert.assertEquals(Assert.java:555)
            at jnr.posix.FileTest.utimesTest(FileTest.java:42)
    
    fcntlDupfdTest(jnr.posix.FileTest)  Time elapsed: 0.003 sec  <<< ERROR!
    java.io.IOException: Bad file descriptor
            at java.io.FileOutputStream.writeBytes(Native Method)
            at java.io.FileOutputStream.write(FileOutputStream.java:313)
            at jnr.posix.FileTest.fcntlDupfdTest(FileTest.java:294)
    
    ftruncateTest(jnr.posix.FileTest)  Time elapsed: 0.002 sec  <<< FAILURE!
    java.lang.AssertionError: expected:<21> but was:<30>
            at org.junit.Assert.fail(Assert.java:88)
            at org.junit.Assert.failNotEquals(Assert.java:743)
            at org.junit.Assert.assertEquals(Assert.java:118)
            at org.junit.Assert.assertEquals(Assert.java:555)
            at org.junit.Assert.assertEquals(Assert.java:542)
            at jnr.posix.FileTest.ftruncateTest(FileTest.java:452)
    
    utimesPointerTest(jnr.posix.FileTest)  Time elapsed: 0.001 sec  <<< FAILURE!
    java.lang.AssertionError: atime seconds failed expected:<800> but was:<900>
            at org.junit.Assert.fail(Assert.java:88)
            at org.junit.Assert.failNotEquals(Assert.java:743)
            at org.junit.Assert.assertEquals(Assert.java:118)
            at org.junit.Assert.assertEquals(Assert.java:555)
            at jnr.posix.FileTest.utimesPointerTest(FileTest.java:95)
    
    utimensatAbsolutePath(jnr.posix.FileTest)  Time elapsed: 0.002 sec  <<< FAILURE!
    java.lang.AssertionError: Access timestamp should be updated expected:<1546085560> but was:<1546085556>
            at org.junit.Assert.fail(Assert.java:88)
            at org.junit.Assert.failNotEquals(Assert.java:743)
            at org.junit.Assert.assertEquals(Assert.java:118)
            at org.junit.Assert.assertEquals(Assert.java:555)
            at jnr.posix.FileTest.assertStatNanoSecond(FileTest.java:661)
            at jnr.posix.FileTest.utimensat(FileTest.java:656)
            at jnr.posix.FileTest.utimensatAbsolutePath(FileTest.java:115)
    
    futimens(jnr.posix.FileTest)  Time elapsed: 0 sec  <<< FAILURE!
    java.lang.AssertionError: Access timestamp should be updated expected:<1546085559> but was:<1546085557>
            at org.junit.Assert.fail(Assert.java:88)
            at org.junit.Assert.failNotEquals(Assert.java:743)
            at org.junit.Assert.assertEquals(Assert.java:118)
            at org.junit.Assert.assertEquals(Assert.java:555)
            at jnr.posix.FileTest.assertStatNanoSecond(FileTest.java:661)
            at jnr.posix.FileTest.futimens(FileTest.java:144)
    
    lutimesTest(jnr.posix.FileTest)  Time elapsed: 0 sec  <<< FAILURE!
    java.lang.AssertionError: atime seconds failed expected:<800> but was:<900>
            at org.junit.Assert.fail(Assert.java:88)
            at org.junit.Assert.failNotEquals(Assert.java:743)
            at org.junit.Assert.assertEquals(Assert.java:118)
            at org.junit.Assert.assertEquals(Assert.java:555)
            at jnr.posix.FileTest.lutimesTest(FileTest.java:162)
    
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.IDTest
    Successfully loaded native POSIX impl.
    Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.915 sec - in jnr.posix.SpawnTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.SignalTest
    Successfully loaded native POSIX impl.
    Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.3 sec - in jnr.posix.IDTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Successfully loaded native POSIX impl.
    Running jnr.posix.CryptTest
    Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.203 sec - in jnr.posix.SignalTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.HANDLETest
    Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.179 sec - in jnr.posix.HANDLETest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.EnvTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.199 sec - in jnr.posix.CryptTest
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.NlLanginfoTest
    Successfully loaded native POSIX impl.
    Tests run: 6, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.076 sec <<< FAILURE! - in jnr.posix.EnvTest
    testEnv(jnr.posix.EnvTest)  Time elapsed: 0.003 sec  <<< ERROR!
    java.lang.UnsupportedOperationException: unimplemented method: environ
            at jnr.posix.DummyPOSIXHandler.unimplementedError(DummyPOSIXHandler.java:29)
            at jnr.posix.CheckedPOSIX.unimplementedNull(CheckedPOSIX.java:25)
            at jnr.posix.CheckedPOSIX.environ(CheckedPOSIX.java:415)
            at jnr.posix.LazyPOSIX.environ(LazyPOSIX.java:410)
            at jnr.posix.EnvTest.testEnv(EnvTest.java:70)
    
    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Running jnr.posix.PasswdTest
    Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.018 sec <<< FAILURE! - in jnr.posix.PasswdTest
    jnr.posix.PasswdTest  Time elapsed: 0.018 sec  <<< ERROR!
    java.lang.IllegalArgumentException: Platform not supported
            at jnr.posix.PasswdTest.setUpClass(PasswdTest.java:36)

    OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
    Successfully loaded native POSIX impl.
    Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.977 sec <<< FAILURE! - in jnr.posix.NlLanginfoTest
    testNlLanginfo(jnr.posix.NlLanginfoTest)  Time elapsed: 0.949 sec  <<< FAILURE!
    org.junit.ComparisonFailure: expected:<[UTF-8]> but was:<[%e de %B de %Y, %H:%M:%S]>
            at org.junit.Assert.assertEquals(Assert.java:115)
            at org.junit.Assert.assertEquals(Assert.java:144)
            at jnr.posix.NlLanginfoTest.testNlLanginfo(NlLanginfoTest.java:32)
    
    Running jnr.posix.ProcessTest
    Successfully loaded native POSIX impl.
    Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.556 sec - in jnr.posix.ProcessTest
    
    Results :
    
    Failed tests: 
      FileTest.ftruncateTest:452 expected:<21> but was:<30>
      FileTest.futimens:144->assertStatNanoSecond:661 Access timestamp should be updated expected:<1546085559> but was:<1546085557>
      FileTest.lutimesTest:162 atime seconds failed expected:<800> but was:<900>
      FileTest.utimensatAbsolutePath:115->utimensat:656->assertStatNanoSecond:661 Access timestamp should be updated expected:<1546085560> but was:<1546085556>
      FileTest.utimensatRelativePath:124->utimensat:656->assertStatNanoSecond:661 Access timestamp should be updated expected:<941406988> but was:<941406984>
      FileTest.utimesPointerTest:95 atime seconds failed expected:<800> but was:<900>
      FileTest.utimesTest:42 atime seconds failed expected:<800> but was:<900>
      IOTest.testOpenReadWrite:34 expected:<5> but was:<-1>
      IOTest.testSendRecvMsg_NoControl:111 null
      IOTest.testSendRecvMsg_WithControl:159 null
      IOTest.testSocketPair:80 null
      NlLanginfoTest.testNlLanginfo:32 expected:<[UTF-8]> but was:<[%e de %B de %Y, %H:%M:%S]>
    Tests in error: 
      EnvTest.testEnv:70 » UnsupportedOperation unimplemented method: environ
      FileTest.dup2Test:275 » IO Bad file descriptor
      FileTest.fcntlDupfdTest:294 » IO Bad file descriptor
      PasswdTest.setUpClass:36 IllegalArgument Platform not supported

    Tests run: 89, Failures: 12, Errors: 4, Skipped: 0
