### PR TITLE
Implement gethostname(); fixes #29

### DIFF
--- a/src/main/java/jnr/posix/BaseNativePOSIX.java
+++ b/src/main/java/jnr/posix/BaseNativePOSIX.java
@@ -3,6 +3,7 @@ package jnr.posix;
 import jnr.constants.Constant;
 import jnr.constants.platform.Errno;
 import jnr.constants.platform.Fcntl;
+import jnr.constants.platform.Signal;
 import jnr.constants.platform.Sysconf;
 import jnr.ffi.*;
 import jnr.ffi.byref.NumberByReference;
@@ -22,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import jnr.constants.platform.Signal;
 
 public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
     private final LibC libc;
@@ -753,6 +753,22 @@ public abstract class BaseNativePOSIX extends NativePOSIX implements POSIX {
 
     public int rename(CharSequence oldName, CharSequence newName) {
         return libc().rename(oldName, newName);
+    }
+
+    public String gethostname() {
+        ByteBuffer buffer = ByteBuffer.allocate(256);
+        int result;
+        try {
+            result = libc().gethostname(buffer, buffer.capacity() - 1);
+        } catch (java.lang.UnsatisfiedLinkError e) {
+            result = -1;
+        }
+        if (result == -1) return helper.gethostname();
+        buffer.position(0);
+        while (buffer.hasRemaining() && buffer.get() != 0);
+        buffer.limit(buffer.position() - 1);
+        buffer.position(0);
+        return Charset.forName("US-ASCII").decode(buffer).toString();
     }
 
     public String getcwd() {

--- a/src/main/java/jnr/posix/CheckedPOSIX.java
+++ b/src/main/java/jnr/posix/CheckedPOSIX.java
@@ -622,4 +622,8 @@ final class CheckedPOSIX implements POSIX {
     public int gettimeofday(Timeval tv) {
         try {return posix.gettimeofday(tv); } catch (UnsatisfiedLinkError ule) { return unimplementedInt(); }
     }
+
+    public String gethostname() {
+        try {return posix.gethostname(); } catch (UnsatisfiedLinkError ule) { return unimplementedNull(); }
+    }
 }

--- a/src/main/java/jnr/posix/JavaLibCHelper.java
+++ b/src/main/java/jnr/posix/JavaLibCHelper.java
@@ -43,7 +43,6 @@ import java.util.regex.Pattern;
 import jnr.constants.platform.Errno;
 import jnr.posix.util.Chmod;
 import jnr.posix.util.ExecIt;
-import jnr.posix.util.FieldAccess;
 import jnr.posix.util.JavaCrypt;
 import jnr.posix.util.Platform;
 
@@ -242,6 +241,12 @@ public class JavaLibCHelper {
 
     public String getlogin() {
         return System.getProperty("user.name");
+    }
+
+    public String gethostname() {
+        String hn = System.getenv("HOSTNAME");
+        if (hn == null) hn = System.getenv("COMPUTERNAME");
+        return hn;
     }
 
     public int getpid() {

--- a/src/main/java/jnr/posix/JavaPOSIX.java
+++ b/src/main/java/jnr/posix/JavaPOSIX.java
@@ -813,6 +813,10 @@ final class JavaPOSIX implements POSIX {
         return -1;
     }
 
+    public String gethostname() {
+        return helper.gethostname();
+    }
+
     static final class LoginInfo {
         public static final int UID = IDHelper.getInt("-u");
         public static final int GID = IDHelper.getInt("-g");

--- a/src/main/java/jnr/posix/LazyPOSIX.java
+++ b/src/main/java/jnr/posix/LazyPOSIX.java
@@ -583,6 +583,10 @@ final class LazyPOSIX implements POSIX {
         return posix().mkfifo(path, mode);
     }
 
+    public String gethostname() {
+        return posix().gethostname();
+    }
+
     public int daemon(int nochdir, int noclose) {
         return posix().daemon(nochdir, noclose);
     }

--- a/src/main/java/jnr/posix/LibC.java
+++ b/src/main/java/jnr/posix/LibC.java
@@ -161,6 +161,7 @@ public interface LibC {
     int ftruncate(int fd, long offset);
     int rename(CharSequence oldName, CharSequence newName);
     long getcwd(byte[] cwd, int len);
+    int gethostname(@Out ByteBuffer buffer, int len);
     int fsync(int fd);
     int fdatasync(int fd);
 

--- a/src/main/java/jnr/posix/POSIX.java
+++ b/src/main/java/jnr/posix/POSIX.java
@@ -190,6 +190,7 @@ public interface POSIX {
     int ftruncate(int fd, long offset);
     int rename(CharSequence oldName, CharSequence newName);
     String getcwd();
+    String gethostname();
 
     int socketpair(int domain, int type, int protocol, int[] fds);
     int sendmsg(int socket, MsgHdr message, int flags);

--- a/src/main/java/jnr/posix/WindowsLibC.java
+++ b/src/main/java/jnr/posix/WindowsLibC.java
@@ -108,6 +108,11 @@ public interface WindowsLibC extends LibC {
             @In WString envValue);
 
     @StdCall
+    boolean GetComputerNameW(
+            @Out ByteBuffer lpBuffer,
+            IntByReference nSize);
+
+    @StdCall
     boolean SetFileTime(
             HANDLE  hFile,
             FileTime lpCreationTime,

--- a/src/main/java/jnr/posix/WindowsPOSIX.java
+++ b/src/main/java/jnr/posix/WindowsPOSIX.java
@@ -14,6 +14,7 @@ import jnr.ffi.mapper.FromNativeContext;
 
 import java.io.FileDescriptor;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -318,6 +319,15 @@ final public class WindowsPOSIX extends BaseNativePOSIX {
         return -1;
     }
 
+    @Override
+    public String gethostname() {
+        ByteBuffer buffer = ByteBuffer.allocate(64);
+        IntByReference len = new IntByReference(buffer.capacity() - 1);
+        if (!wlibc().GetComputerNameW(buffer, len)) return helper.gethostname();
+        buffer.limit(len.intValue() * 2);
+        return Charset.forName("UTF-16LE").decode(buffer).toString();
+    }
+    
     public FileStat fstat(int fd) {
         WindowsFileStat stat = new WindowsFileStat(this);
         if (fstat(fd, stat) < 0) handler.error(Errno.valueOf(errno()), "fstat", "" + fd);

--- a/src/test/java/jnr/posix/HostnameTest.java
+++ b/src/test/java/jnr/posix/HostnameTest.java
@@ -1,0 +1,45 @@
+package jnr.posix;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+
+import java.io.IOException;
+import java.util.Scanner;
+
+public class HostnameTest {
+    private static POSIX posix;
+    private static POSIX jPosix;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        posix = POSIXFactory.getPOSIX(new DummyPOSIXHandler(), true);
+        jPosix = POSIXFactory.getJavaPOSIX();
+    }
+
+    @Test
+    public void testHostnameWorks() {
+        assertNotNull(posix.gethostname());
+    }
+    
+    @Test
+    public void jPosixIsReasonable() {
+        assumeThat(System.getenv().keySet(), anyOf(hasItem("HOSTNAME"), hasItem("COMPUTERNAME")));
+        assertNotNull(jPosix.gethostname());
+    }
+
+    @Test
+    public void testHostnameIsResonable() throws IOException {
+        String hostname = "";
+        try {
+            hostname = new Scanner(Runtime.getRuntime().exec("hostname").getInputStream()).next();
+        } catch (IOException e) {
+            assumeNoException(e);
+        }
+        assumeThat(hostname, is(not(equalTo(""))));
+        assertThat(posix.gethostname().toLowerCase(), equalTo(hostname.toLowerCase()));
+    }
+}


### PR DESCRIPTION
This is a revival of #66 - now with proper Windows support and some basic tests.

Some notes:
- The test assumes (so it won't fail) the presence of a "hostname" command line tool to verify the return value of the native implementation - This exists and gives the correct result on Windows 10 and Debian unstable
- Similar, the fallback (`JavaPosix`) helper is only tested if its requirements are fulfilled.