### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: java
 matrix:
   include:
     - os: linux
+      dist: trusty
       jdk: openjdk7
     - os: linux
       jdk: openjdk8
@@ -18,6 +19,8 @@ matrix:
     - os: osx
       jdk: openjdk11
       osx_image: xcode10.1
+
+dist: xenial
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: java
-sudo: true
 
-before_install:
-   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
-   - echo $JAVA_HOME
-   
 matrix:
   include:
     - os: linux
@@ -17,9 +12,12 @@ matrix:
       jdk: openjdk10
     - os: linux
       jdk: openjdk11
-
-os:
-  - linux
+    - os: osx
+      # This uses Oracle JDK 8
+      osx_image: xcode9.3
+    - os: osx
+      jdk: openjdk11
+      osx_image: xcode10.1
 
 notifications:
   irc:


### PR DESCRIPTION
As noticed in #129, Travis-CI seems to be disabled for this repository.
This tries to fix that and enables Travis-CI for Linux and OS X builds.

(This is probably not enough to get Travis-CI to run again. An admin needs to re-enable the project on https://travis-ci.org/jnr/jnr-posix - It seems to have been disabled between 2019-01-09 and now)