### PR TITLE
FreeBSD 12 support

### DIFF
--- a/src/main/java/jnr/posix/FreeBSDFileStat.java
+++ b/src/main/java/jnr/posix/FreeBSDFileStat.java
@@ -44,11 +44,15 @@ public final class FreeBSDFileStat extends BaseFileStat implements NanosecondFil
         public final class dev_t extends Signed32 {}
 
         public final dev_t  st_dev = new dev_t();
-        public final Signed32  st_ino = new Signed32();
+        public final Signed64  st_ino = new Signed64();
+        // FIXME: this should be a 64-bit field
+        public final Signed32  st_nlink_upper = new Signed32();
+        public final Signed32  st_nlink = new Signed32();
         public final Signed16  st_mode = new Signed16();
-        public final Signed16  st_nlink = new Signed16();
+        public final Signed16  st_padding0 = new Signed16();
         public final Signed32  st_uid = new Signed32();
         public final Signed32  st_gid = new Signed32();
+        public final Signed32  st_padding1 = new Signed32();
         public final dev_t  st_rdev = new dev_t();
         public final time_t st_atime = new time_t();
         public final SignedLong st_atimensec = new SignedLong();
@@ -56,14 +60,13 @@ public final class FreeBSDFileStat extends BaseFileStat implements NanosecondFil
         public final SignedLong st_mtimensec = new SignedLong();
         public final time_t st_ctime = new time_t();
         public final SignedLong st_ctimensec = new SignedLong();
+        public final time_t    st_birthtime = new time_t();
+        public final SignedLong st_birthtimensec = new SignedLong();
         public final Signed64  st_size = new Signed64();
         public final Signed64  st_blocks = new Signed64();
         public final Signed32  st_blksize = new Signed32();
         public final Signed32  st_flags = new Signed32();
-        public final Signed32  st_gen = new Signed32();
-        public final Signed32  st_lspare = new Signed32();
-        public final time_t    st_birthtime = new time_t();
-        public final SignedLong st_birthtimensec = new SignedLong();
+        public final Signed64  st_gen = new Signed64();
         /* FIXME: This padding isn't quite correct */
         public final Signed64  st_qspare0 = new Signed64();
     }

--- a/src/main/java/jnr/posix/FreeBSDFileStat12.java
+++ b/src/main/java/jnr/posix/FreeBSDFileStat12.java
@@ -33,7 +33,7 @@ package jnr.posix;
 
 import jnr.ffi.StructLayout;
 
-public final class FreeBSDFileStat extends BaseFileStat implements NanosecondFileStat {
+public final class FreeBSDFileStat12 extends BaseFileStat implements NanosecondFileStat {
     private static final class Layout extends StructLayout {
 
         private Layout(jnr.ffi.Runtime runtime) {
@@ -44,11 +44,15 @@ public final class FreeBSDFileStat extends BaseFileStat implements NanosecondFil
         public final class dev_t extends Signed32 {}
 
         public final dev_t  st_dev = new dev_t();
-        public final Signed32  st_ino = new Signed32();
+        public final Signed64  st_ino = new Signed64();
+        // FIXME: this should be a 64-bit field
+        public final Signed32  st_nlink_upper = new Signed32();
+        public final Signed32  st_nlink = new Signed32();
         public final Signed16  st_mode = new Signed16();
-        public final Signed16  st_nlink = new Signed16();
+        public final Signed16  st_padding0 = new Signed16();
         public final Signed32  st_uid = new Signed32();
         public final Signed32  st_gid = new Signed32();
+        public final Signed32  st_padding1 = new Signed32();
         public final dev_t  st_rdev = new dev_t();
         public final time_t st_atime = new time_t();
         public final SignedLong st_atimensec = new SignedLong();
@@ -56,20 +60,19 @@ public final class FreeBSDFileStat extends BaseFileStat implements NanosecondFil
         public final SignedLong st_mtimensec = new SignedLong();
         public final time_t st_ctime = new time_t();
         public final SignedLong st_ctimensec = new SignedLong();
+        public final time_t    st_birthtime = new time_t();
+        public final SignedLong st_birthtimensec = new SignedLong();
         public final Signed64  st_size = new Signed64();
         public final Signed64  st_blocks = new Signed64();
         public final Signed32  st_blksize = new Signed32();
         public final Signed32  st_flags = new Signed32();
-        public final Signed32  st_gen = new Signed32();
-        public final Signed32  st_lspare = new Signed32();
-        public final time_t    st_birthtime = new time_t();
-        public final SignedLong st_birthtimensec = new SignedLong();
+        public final Signed64  st_gen = new Signed64();
         /* FIXME: This padding isn't quite correct */
         public final Signed64  st_qspare0 = new Signed64();
     }
     private static final Layout layout = new Layout(jnr.ffi.Runtime.getSystemRuntime());
 
-    public FreeBSDFileStat(NativePOSIX posix) {
+    public FreeBSDFileStat12(NativePOSIX posix) {
         super(posix, layout);
     }
 

--- a/src/main/java/jnr/posix/FreeBSDPOSIX.java
+++ b/src/main/java/jnr/posix/FreeBSDPOSIX.java
@@ -43,7 +43,11 @@ final class FreeBSDPOSIX extends BaseNativePOSIX {
     }
     
     public FileStat allocateStat() {
-        return new FreeBSDFileStat(this);
+        if (System.getProperty("os.version").compareTo("12.0") > 0) {
+            return new FreeBSDFileStat12(this);
+        } else {
+            return new FreeBSDFileStat(this);
+        }
     }
 
     public MsgHdr allocateMsgHdr() {


### PR DESCRIPTION
As per #126, this adds support for FreeBSD 12's new `struct stat` layout, detecting the appropriate version to use using `freebsd-version`.

Once jffi supports symbol versioning this should be replaced.