### PR TITLE
Unbreak on FreeBSD 12+

### DIFF
--- a/src/main/java/jnr/posix/FreeBSDLibC.java
+++ b/src/main/java/jnr/posix/FreeBSDLibC.java
@@ -1,0 +1,20 @@
+package jnr.posix;
+
+import jnr.ffi.annotations.Out;
+import jnr.ffi.annotations.Transient;
+import jnr.ffi.annotations.Version;
+
+public interface FreeBSDLibC extends UnixLibC {
+    @Version("FBSD_1.0")
+    int fstat(int fd, @Out @Transient FileStat stat);
+    @Version("FBSD_1.0")
+    int fstat64(int fd, @Out @Transient FileStat stat);
+    @Version("FBSD_1.0")
+    int lstat(CharSequence path, @Out @Transient FileStat stat);
+    @Version("FBSD_1.0")
+    int lstat64(CharSequence path, @Out @Transient FileStat stat);
+    @Version("FBSD_1.0")
+    int stat(CharSequence path, @Out @Transient FileStat stat);
+    @Version("FBSD_1.0")
+    int stat64(CharSequence path, @Out @Transient FileStat stat);
+}

--- a/src/main/java/jnr/posix/POSIXFactory.java
+++ b/src/main/java/jnr/posix/POSIXFactory.java
@@ -202,6 +202,9 @@ public class POSIXFactory {
             
             case AIX:
                 return AixLibC.class;
+
+            case FREEBSD:
+                return FreeBSDLibC.class;
             
             case SOLARIS:
                 return SolarisLibC.class;


### PR DESCRIPTION
This is a follow-up to https://github.com/jnr/jnr-ffi/pull/189, which is a follow-up to https://github.com/jnr/jffi/pull/66.

---

FreeBSD 12 switched to 64 bits inodes, and struct stat was updated accordingly:
https://github.com/freebsd/freebsd/commit/e75ba1d5c4c79376a78351c8544388491db49664

On recent FreeBSD, due to struct stat size change, jnr-posix acts inconsistently.

Fix the issue by forcing usage of the legacy API which is available through versioned symbols.

Running the test suite on FreeBSD before this change produces:

> Tests run: 93, Failures: 10, Errors: 3, Skipped: 1
>
> Failed tests:
>   FileStatTest.filestat:63 expected:<1567> but was:<149054000>
>   FileStatTest.filestatDirectory:196 null
>   FileTest.futimeTest:185 mtime failed
>   FileTest.futimens:144->assertStatNanoSecond:661 Access timestamp should be updated expected:<4299262296485> but was:<4299262296484>
>   FileTest.lutimesTest:162 atime seconds failed expected:<800> but was:<4299262296484>
>   FileTest.utimensatAbsolutePath:115->utimensat:656->assertStatNanoSecond:661 Access timestamp should be updated expected:<4299262296486> but was:<4299262296484>
>   FileTest.utimensatRelativePath:124->utimensat:656->assertStatNanoSecond:661 Access timestamp should be updated expected:<4299262296486> but was:<4299262296484>
>   FileTest.utimesDefaultValuesTest:73 mtime failed
>   FileTest.utimesPointerTest:95 atime seconds failed expected:<800> but was:<4299262296484>
>   FileTest.utimesTest:42 atime seconds failed expected:<800> but was:<4299262296484>

With this change, the results are:

> Tests run: 93, Failures: 0, Errors: 3, Skipped: 1

Tests in error rely on unimplemented methods for FreeBSD and are
expected:

> Tests in error:
>   EnvTest.testEnv:70 » UnsupportedOperation unimplemented method: environ
>   IOTest.testSendRecvMsg_NoControl:115 » UnsupportedOperation unimplemented method: allocateMsgHdr
>   IOTest.testSendRecvMsg_WithControl:163 » UnsupportedOperation unimplemented method: allocateMsgHdr