### PR TITLE
Search the default image for symbols to allow patching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.1.13</version>
+      <version>2.1.14-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>

--- a/src/main/java/jnr/posix/POSIXFactory.java
+++ b/src/main/java/jnr/posix/POSIXFactory.java
@@ -286,9 +286,26 @@ public class POSIXFactory {
         public static final LibCProvider INSTANCE = new DefaultLibCProvider();
 
         private static final class SingletonHolder {
-            public static LibC libc = Library.loadLibrary(libraryInterface(), options(), libraries());
+            public static LibC libc;
             public static Crypt crypt;
             static {
+                LibraryLoader<? extends LibC> libcLoader = LibraryLoader.create(libraryInterface());
+
+                // always do a default search
+                libcLoader.searchDefault();
+
+                for (String library : libraries()) {
+                    libcLoader.library(library);
+                }
+
+                for (Map.Entry<LibraryOption, Object> entry : options().entrySet()) {
+                    libcLoader.option(entry.getKey(), entry.getValue());
+                }
+
+                libcLoader.failImmediately();
+
+                libc = libcLoader.load();
+
                 Crypt c = null;
 
                 // FIXME: This is kinda gross but there's no way to tell jnr-ffi that some libraries are ok to fail


### PR DESCRIPTION
This addresses the issue in jruby/jruby#6202 where patch libraries
loaded via LD_PRELOAD on Linux or DYLD_INSERT_LIBRARIES on MacOS
would not be seen, since we go directly to the system libc and
acquire all symbols from there. The patch utilizes the work in
jnr/jnr-ffi#204 to unconditionally add a default search to the
library bootstrapping.

This is part of work to implement #147.

Note that this does not provide a way to opt-out of searching the
default image due to the static native of how the POSIX LibC
library wrapper gets set up. A larger change will be needed to
allow configuring this behavior.