### PR TITLE
Fixes for pure-Java mode

### DIFF
--- a/src/main/java/jnr/posix/JavaLibCHelper.java
+++ b/src/main/java/jnr/posix/JavaLibCHelper.java
@@ -366,14 +366,17 @@ public class JavaLibCHelper {
         try {
             File file = new JavaSecuredFile(path);
             
-            if (!file.exists()) return -1;
-                
+            if (!file.exists()) {
+                errno(ENOENT);
+                return -1;
+            }
+
             jstat.setup(file.getCanonicalPath());
         } catch (IOException e) {
             // TODO: Throw error when we have problems stat'ing canonicalizing
         }
 
-        // TODO: Add error reporting for cases we can calculate: ENOTDIR, ENAMETOOLONG, ENOENT
+        // TODO: Add error reporting for cases we can calculate: ENOTDIR, ENAMETOOLONG,
         // EACCES, ELOOP, EFAULT, EIO
 
         return 0;

--- a/src/test/java/jnr/posix/JavaPOSIXTest.java
+++ b/src/test/java/jnr/posix/JavaPOSIXTest.java
@@ -8,6 +8,7 @@ package jnr.posix;
 import java.io.File;
 import java.io.IOException;
 
+import jnr.constants.platform.Errno;
 import jnr.posix.JavaPOSIX;
 import jnr.posix.POSIX;
 import jnr.posix.Passwd;
@@ -73,6 +74,15 @@ public class JavaPOSIXTest {
         ret = posix.lstat(file.getPath(), stat);
 
         assertTrue(ret < 0);
+    }
+
+    @Test public void statMissingFileTest() throws IOException {
+        FileStat stat = posix.allocateStat();
+
+        int ret = posix.stat("does not exist", stat);
+
+        assertEquals(-1, ret);
+        assertEquals(Errno.ENOENT.intValue(), posix.errno());
     }
 
 	@Test


### PR DESCRIPTION
Various fixes for when we can't use the native calls... trying to get pure-Java mode to support more use cases.

This is driven by work on https://github.com/jruby/jruby/pull/6383 on macOS/AArch64.