### PR TITLE
don't call libc directly

### DIFF
--- a/src/main/java/jnr/posix/LazyPOSIX.java
+++ b/src/main/java/jnr/posix/LazyPOSIX.java
@@ -439,11 +439,11 @@ final class LazyPOSIX implements POSIX {
     }
 
     public int confstr(Confstr name, ByteBuffer buf, int len) {
-        return libc().confstr(name, buf, len);
+        return posix().confstr(name, buf, len);
     }
 
     public int fpathconf(int fd, Pathconf name) {
-        return libc().fpathconf(fd, name);
+        return posix().fpathconf(fd, name);
     }
 
     public Times times() {

--- a/src/test/java/jnr/posix/ConfstrTest.java
+++ b/src/test/java/jnr/posix/ConfstrTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import java.nio.ByteBuffer;
 import jnr.constants.platform.Confstr;
+import jnr.constants.platform.Errno;
 import jnr.posix.util.Platform;
 
 public class ConfstrTest {
@@ -16,7 +17,11 @@ public class ConfstrTest {
 
     @Test
     public void confstr() {
-        if (!Platform.IS_WINDOWS) {
+        if (Platform.IS_WINDOWS) {
+            int len = posix.confstr(Confstr._CS_PATH, null, 0);
+            assertEquals(-1, len);
+            assertEquals(Errno.EOPNOTSUPP.intValue(), posix.errno());
+        } else {
             int len = posix.confstr(Confstr._CS_PATH, null, 0);
             assertTrue("bad strlen", len > 0);
 

--- a/src/test/java/jnr/posix/IOTest.java
+++ b/src/test/java/jnr/posix/IOTest.java
@@ -72,7 +72,11 @@ public class IOTest {
 
     @Test
     public void testPathconf() {
-        if (!Platform.IS_WINDOWS) {
+        if (Platform.IS_WINDOWS) {
+            int res = posix.fpathconf(-1, Pathconf._PC_PIPE_BUF);
+            Assert.assertEquals(-1, res);
+            Assert.assertEquals(Errno.EOPNOTSUPP.intValue(), posix.errno());
+        } else {
             int res = posix.fpathconf(-1, Pathconf._PC_PIPE_BUF);
             Assert.assertEquals(-1, res);
             


### PR DESCRIPTION
sry for a typo

fixes ```java.lang.UnsatisfiedLinkError``` on Windows