### PR TITLE
add mips64's file stat support

### DIFF
--- a/src/main/java/jnr/posix/LinuxFileStatMIPS64.java
+++ b/src/main/java/jnr/posix/LinuxFileStatMIPS64.java
@@ -1,0 +1,110 @@
+package jnr.posix;
+
+import jnr.ffi.StructLayout;
+
+public final class LinuxFileStatMIPS64 extends BaseFileStat implements NanosecondFileStat {
+    public static final class Layout extends StructLayout {
+
+        public Layout(jnr.ffi.Runtime runtime) {
+            super(runtime);
+        }
+
+        public final Unsigned64 st_dev = new Unsigned64();
+        public final Unsigned32 __pad01 = new Unsigned32();
+        public final Unsigned32 __pad02 = new Unsigned32();
+        public final Unsigned32 __pad03 = new Unsigned32();
+
+        public final Unsigned64 st_ino = new Unsigned64();
+        public final Unsigned64 st_mode = new Unsigned64();
+        public final Unsigned32 st_nlink = new Unsigned32();
+        public final Unsigned32 st_uid = new Unsigned32();
+        public final Unsigned32 st_gid = new Unsigned32();
+        public final Unsigned64 st_rdev = new Unsigned64();
+	public final Unsigned32 __pad11 = new Unsigned32();
+        public final Unsigned32 __pad12 = new Unsigned32();
+        public final Unsigned32 __pad13 = new Unsigned32();
+
+        public final Signed64	st_size = new Signed64();
+
+        public final Unsigned64	st_atime = new Unsigned64();     // Time of last access (time_t)
+        public final Unsigned64	st_atimensec = new Unsigned64(); // Time of last access (nanoseconds)
+        public final Unsigned64	st_mtime = new Unsigned64();     // Last data modification time (time_t)
+        public final Unsigned64	st_mtimensec = new Unsigned64(); // Last data modification time (nanoseconds)
+        public final Unsigned64	st_ctime = new Unsigned64();     // Time of last status change (time_t)
+        public final Unsigned64	st_ctimensec = new Unsigned64(); // Time of last status change (nanoseconds)
+
+        public final Unsigned64	st_blksize = new Unsigned64();
+        public final Unsigned32	__pad20 = new Unsigned32();
+        public final Unsigned64	st_blocks = new Unsigned64();
+    }
+
+    private static final Layout layout = new Layout(jnr.ffi.Runtime.getSystemRuntime());
+
+    public LinuxFileStatMIPS64(LinuxPOSIX posix) {
+        super(posix, layout);
+    }
+
+    public long atime() {
+        return layout.st_atime.get(memory);
+    }
+
+    public long aTimeNanoSecs() {
+        return layout.st_atimensec.get(memory);
+    }
+
+    public long blockSize() {
+        return layout.st_blksize.get(memory);
+    }
+
+    public long blocks() {
+        return layout.st_blocks.get(memory);
+    }
+
+    public long ctime() {
+        return layout.st_ctime.get(memory);
+    }
+
+    public long cTimeNanoSecs() {
+        return layout.st_ctimensec.get(memory);
+    }
+
+    public long dev() {
+        return layout.st_dev.get(memory);
+    }
+
+    public int gid() {
+        return (int) layout.st_gid.get(memory);
+    }
+
+    public long ino() {
+        return layout.st_ino.get(memory);
+    }
+
+    public int mode() {
+        return (int) layout.st_mode.get(memory);
+    }
+
+    public long mtime() {
+        return layout.st_mtime.get(memory);
+    }
+
+    public long mTimeNanoSecs() {
+        return layout.st_mtimensec.get(memory);
+    }
+
+    public int nlink() {
+        return (int) layout.st_nlink.get(memory);
+    }
+
+    public long rdev() {
+        return layout.st_rdev.get(memory);
+    }
+
+    public long st_size() {
+        return layout. st_size.get(memory);
+    }
+
+    public int uid() {
+        return (int) layout.st_uid.get(memory);
+    }
+}

--- a/src/main/java/jnr/posix/LinuxPOSIX.java
+++ b/src/main/java/jnr/posix/LinuxPOSIX.java
@@ -23,7 +23,7 @@ final class LinuxPOSIX extends BaseNativePOSIX implements Linux {
         super(libcProvider, handler);
 
 
-        if (Platform.IS_32_BIT || "sparcv9".equals(Platform.ARCH)) {
+        if (Platform.IS_32_BIT || "sparcv9".equals(Platform.ARCH) || Platform.ARCH.contains("mips64")) {
             statVersion = 3;
         } else {
             FileStat stat = allocateStat();
@@ -47,6 +47,9 @@ final class LinuxPOSIX extends BaseNativePOSIX implements Linux {
                 if ("sparcv9".equals(Platform.ARCH)) {
                     return new LinuxFileStatSPARCV9(this);
                 } else{
+		    if (Platform.ARCH.contains("mips64")) {
+		    	return new LinuxFileStatMIPS64(this);
+		    }
                     return new LinuxFileStat64(this);
                 }
             }
@@ -215,6 +218,7 @@ final class LinuxPOSIX extends BaseNativePOSIX implements Linux {
         static final ABI _ABI_AARCH64 = new ABI_AARCH64();
         static final ABI _ABI_SPARCV9 = new ABI_SPARCV9();
         static final ABI _ABI_PPC64 = new ABI_PPC64();
+        static final ABI _ABI_MIPS64 = new ABI_MIPS64();
 
         public static ABI abi() {
             if ("x86_64".equals(Platform.ARCH)) {
@@ -229,7 +233,9 @@ final class LinuxPOSIX extends BaseNativePOSIX implements Linux {
                 return _ABI_SPARCV9;
             } else if (Platform.ARCH.contains("ppc64")) {
                 return _ABI_PPC64;
-            }
+            } else if (Platform.ARCH.contains("mips64")) {
+	    	return _ABI_MIPS64;
+	    }
             return null;
         }
 
@@ -295,6 +301,18 @@ final class LinuxPOSIX extends BaseNativePOSIX implements Linux {
             @Override
             public int __NR_ioprio_get() {
                 return 274 ;
+            }
+        }
+
+        /** @see /usr/include/asm/unistd.h */
+        final static class ABI_MIPS64 implements ABI {
+            @Override
+            public int __NR_ioprio_set() {
+                return 5273;
+            }
+            @Override
+            public int __NR_ioprio_get() {
+                return 5274;
             }
         }
     }


### PR DESCRIPTION
```
Results :

Failed tests: 
  FileTest.accessTest:509 access /tmp/jnr-posix-access-test17863239778658046659tmp for write:  expected:<-1> but was:<0>
  FileTest.readlinkPointerTest:581 expected:</tmp/jnr-p[?six-r??dl?nk-t?]st174392994513805389...> but was:</tmp/jnr-p[?six-r??dl?nk-t?]st174392994513805389...>
  IOTest.testSendRecvMsg_WithControl:204 null
  LinuxPOSIXTest.testMessageHdrMultipleControl:116 null
  ProcessTest.testGetRLimit:49 Bad soft limit for number of processes
  ProcessTest.testGetRLimitPointer:83 Bad soft limit for number of processes
  ProcessTest.testGetRLimitPreallocatedRlimit:66 Bad soft limit for number of processes

Tests run: 101, Failures: 7, Errors: 0, Skipped: 0
```
The filestat part tests passed. Rlimit not pass maybe due to the operating system configuration. The reasons for the remaining Failures i still need to study.

On the basis of this patch, logstash has been able to work correctly on mips64.

Finally pay tribute to the dying mips. Maybe it's time to learn about riscv.