### PR TITLE
Update struct layout for aarch64 linux to match value on device

### DIFF
--- a/src/main/java/jnr/posix/LinuxFileStatAARCH64.java
+++ b/src/main/java/jnr/posix/LinuxFileStatAARCH64.java
@@ -17,8 +17,10 @@ public final class LinuxFileStatAARCH64 extends BaseFileStat implements Nanoseco
         public final uid_t st_uid = new uid_t();
         public final gid_t st_gid = new gid_t();
         public final dev_t st_rdev = new dev_t();
+        public final dev_t __pad1 = new dev_t();
         public final off_t st_size = new off_t();
         public final blksize_t st_blksize = new blksize_t();
+        public final Signed32 __pad2 = new Signed32();
         public final blkcnt_t st_blocks = new blkcnt_t();
         public final time_t st_atime = new time_t();             // Time of last access
         public final SignedLong st_atimensec = new SignedLong(); // Time of last access (nanoseconds)
@@ -26,7 +28,8 @@ public final class LinuxFileStatAARCH64 extends BaseFileStat implements Nanoseco
         public final SignedLong st_mtimensec = new SignedLong(); // Last data modification time (nanoseconds)
         public final time_t st_ctime = new time_t();             // Time of last status change
         public final SignedLong st_ctimensec = new SignedLong(); // Time of last status change (nanoseconds)
-        public final Signed64 __unused4 = new Signed64();
+        public final Signed32 __unused4 = new Signed32();
+        public final Signed32 __unused5 = new Signed32();
     }
 
     private static final Layout layout = new Layout(jnr.ffi.Runtime.getSystemRuntime());

--- a/src/test/java/jnr/posix/FileStatTest.java
+++ b/src/test/java/jnr/posix/FileStatTest.java
@@ -61,6 +61,7 @@ public class FileStatTest {
             FileStat stat = posix.stat(f.getAbsolutePath());
             assertNotNull("posix.stat failed", stat);
             assertEquals(size, stat.st_size());
+            assertEquals(1, stat.nlink());
             //assertNotEquals(stat.mtime(), stat.ctime());
 
             stat = posix.allocateStat();


### PR DESCRIPTION
The struct layout for aarch64 linux does not match that on AWS graviton2 nodes,
missing several entries.

This commit updates the layout to match the `stat` structure obtained from the
device:

```
pahole -C stat /usr/lib/debug/lib64/libc.so.6.debug

struct stat {
	__dev_t                    st_dev;               /*     0     8 */
	__ino_t                    st_ino;               /*     8     8 */
	__mode_t                   st_mode;              /*    16     4 */
	__nlink_t                  st_nlink;             /*    20     4 */
	__uid_t                    st_uid;               /*    24     4 */
	__gid_t                    st_gid;               /*    28     4 */
	__dev_t                    st_rdev;              /*    32     8 */
	__dev_t                    __pad1;               /*    40     8 */
	__off_t                    st_size;              /*    48     8 */
	__blksize_t                st_blksize;           /*    56     4 */
	int                        __pad2;               /*    60     4 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	__blkcnt_t                 st_blocks;            /*    64     8 */
	struct timespec            st_atim;              /*    72    16 */
	struct timespec            st_mtim;              /*    88    16 */
	struct timespec            st_ctim;              /*   104    16 */
	int                        __glibc_reserved[2];  /*   120     8 */

	/* size: 128, cachelines: 2, members: 16 */
};
```

This commit also updates the unit test for FileStat to include a test to
verify `nlink` values - this was failing prior to this update.

Relates: #164 