### PR TITLE
Update jnr-constants for arch support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-constants</artifactId>
-      <version>0.10.1</version>
+      <version>0.10.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This is for #166, pulling in arch-specific Linux constants from
jnr/jnr-constants#98.