### PR TITLE
Use Variadic annotation to support more platforms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.2.10</version>
+      <version>2.2.11-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>

--- a/src/main/java/jnr/posix/LibC.java
+++ b/src/main/java/jnr/posix/LibC.java
@@ -85,10 +85,14 @@ public interface LibC {
     int dup(int fd);
     int dup2(int oldFd, int newFd);
 
+    @Variadic(fixedCount = 2)
     int fcntl(int fd, int fnctl, Flock arg);
+    @Variadic(fixedCount = 2)
     int fcntl(int fd, int fnctl, Pointer arg);
+    @Variadic(fixedCount = 2)
     int fcntl(int fd, int fnctl);
-    int fcntl(int fd, int fnctl, int arg);
+    @Variadic(fixedCount = 2)
+    int fcntl(int fd, int fnctl, @u_int64_t int arg);
     @Deprecated
     int fcntl(int fd, int fnctl, int... arg);
     int access(CharSequence path, int amode);
@@ -164,6 +168,7 @@ public interface LibC {
     
     int flock(int fd, int mode);
     int unlink(CharSequence path);
+    @Variadic(fixedCount = 2)
     int open(CharSequence path, int flags, int perm);
     int pipe(@Out int[] fds);
     int truncate(CharSequence path, long length);

--- a/src/main/java/jnr/posix/LibC.java
+++ b/src/main/java/jnr/posix/LibC.java
@@ -169,7 +169,7 @@ public interface LibC {
     int flock(int fd, int mode);
     int unlink(CharSequence path);
     @Variadic(fixedCount = 2)
-    int open(CharSequence path, int flags, int perm);
+    int open(CharSequence path, int flags, @u_int32_t int perm);
     int pipe(@Out int[] fds);
     int truncate(CharSequence path, long length);
     int ftruncate(int fd, long offset);

--- a/src/test/java/jnr/posix/FileTest.java
+++ b/src/test/java/jnr/posix/FileTest.java
@@ -380,6 +380,15 @@ public class FileTest {
 
         result = posix.close(fd);
         assertEquals(-1, result);
+
+        fd = posix.open("jnr-posix-filetest.txt", OpenFlags.O_CREAT.intValue() | OpenFlags.O_RDWR.intValue(), 0666);
+
+        assertEquals(0666, posix.stat("jnr-posix-filetest.txt").mode() & 0777);
+
+        result = posix.close(fd);
+        assertEquals(0, result);
+
+        new File("jnr-posix-filetest.txt").delete();
     }
 
     @Test

--- a/src/test/java/jnr/posix/FileTest.java
+++ b/src/test/java/jnr/posix/FileTest.java
@@ -381,9 +381,9 @@ public class FileTest {
         result = posix.close(fd);
         assertEquals(-1, result);
 
-        fd = posix.open("jnr-posix-filetest.txt", OpenFlags.O_CREAT.intValue() | OpenFlags.O_RDWR.intValue(), 0666);
+        fd = posix.open("jnr-posix-filetest.txt", OpenFlags.O_CREAT.intValue() | OpenFlags.O_RDWR.intValue(), 0600);
 
-        assertEquals(0666, posix.stat("jnr-posix-filetest.txt").mode() & 0777);
+        assertEquals(0600, posix.stat("jnr-posix-filetest.txt").mode() & 0777);
 
         result = posix.close(fd);
         assertEquals(0, result);


### PR DESCRIPTION
Apple Silicon (at least) handles variadic arguments differently than fixed arguments. In order to support CPUs like M1 we need to indicate to jnr-ffi exactly how many arguments in a bound function are fixed, so that the additional varargs can be handled properly. When Java varargs are used, this fixed count is apparent, but when we are not using Java varargs an additional `Variadic` annotation is required.

This PR adds the Variadic annotation to `fcntl` and `open`. It also adds a type annotation to the int form of `fcntl` indicating that it should be marshaled as an unsigned 64-bit integer. This appears to be necessary to make it work properly on M1.