### PR TITLE
Update to jnr-ffi-2.2.14 and jffi-1.3.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.2.13</version>
+      <version>2.2.14-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>


### PR DESCRIPTION
This PR is to update to and test against the new debian:8 build of jffi from https://github.com/jnr/jffi/pull/140, intended to fix https://github.com/jnr/jffi/issues/138.

Update to the released versions (not snapshots) of jffi and jnr-ffi before merging.