### PR TITLE
Fix flaky tests

### DIFF
--- a/src/test/java/jnr/posix/EnvTest.java
+++ b/src/test/java/jnr/posix/EnvTest.java
@@ -39,6 +39,7 @@ public class EnvTest {
 
             assertEquals(0, result);
             assertNotEquals(path, posix.getenv("PATH"));
+            posix.setenv("PATH", path, 1);
         }
     }
 


### PR DESCRIPTION
This PR is to fix flaky tests.

### Problem
 If test `jnr.posix.EnvTest#testSetenvOverwrite` runs before any of the following 6 tests, it will pollute the shared status, thus these 6 tests will fail:
```
jnr.posix.GroupTest#getgroups,
jnr.posix.NlLanginfoTest#testNlLanginfo,
jnr.posix.SpawnTest#closeInput,
jnr.posix.SpawnTest#inputPipe,
jnr.posix.SpawnTest#outputPipe,
jnr.posix.SpawnTest#validPid
```
For example, we get the following test failures:
```
[ERROR] Failures: 
[ERROR]   SpawnTest.closeInput:182
[ERROR]   SpawnTest.inputPipe:107
[ERROR]   SpawnTest.outputPipe:73
[ERROR]   SpawnTest.validPid:44
[ERROR] Errors: 
[ERROR]   GroupTest.getgroups:92->exec:122 » IO Cannot run program "id": error=2, No such file or directory
[ERROR]   NlLanginfoTest.testNlLanginfo:28 » IO Cannot run program "locale": error=2, No such file or directory
```
### Root cause and fix:
Line 38 of `jnr.posix.EnvTest#testSetenvOverwrite` changes the property related to `"PATH"` to `"new value"`, but at the end of the test, it didn't reset it back. Therefore, the fix is to change it back at the end of test, which can clean the pollution to other tests.
