### PR TITLE
let `SunMiscSignal#signal()` return default handler, too

### DIFF
--- a/src/main/java/jnr/posix/util/SunMiscSignal.java
+++ b/src/main/java/jnr/posix/util/SunMiscSignal.java
@@ -10,10 +10,8 @@ public class SunMiscSignal {
         sun.misc.SignalHandler oldHandler = Signal.handle(s, new SunMiscSignalHandler(handler));
 
         if (oldHandler instanceof SunMiscSignalHandler) {
-            // previous custom handler
             return ((SunMiscSignalHandler)oldHandler).handler;
         } else if (oldHandler != null) {
-            // default handler
             return any -> oldHandler.handle(s);
         } else {
             return null;

--- a/src/main/java/jnr/posix/util/SunMiscSignal.java
+++ b/src/main/java/jnr/posix/util/SunMiscSignal.java
@@ -10,8 +10,10 @@ public class SunMiscSignal {
         sun.misc.SignalHandler oldHandler = Signal.handle(s, new SunMiscSignalHandler(handler));
 
         if (oldHandler instanceof SunMiscSignalHandler) {
+            // previous custom handler
             return ((SunMiscSignalHandler)oldHandler).handler;
         } else if (oldHandler != null) {
+            // default handler
             return any -> oldHandler.handle(s);
         } else {
             return null;

--- a/src/main/java/jnr/posix/util/SunMiscSignal.java
+++ b/src/main/java/jnr/posix/util/SunMiscSignal.java
@@ -12,7 +12,12 @@ public class SunMiscSignal {
         if (oldHandler instanceof SunMiscSignalHandler) {
             return ((SunMiscSignalHandler)oldHandler).handler;
         } else if (oldHandler != null) {
-            return any -> oldHandler.handle(s);
+            return new SignalHandler() {
+                @Override
+                public void handle(int signal) {
+                    oldHandler.handle(s);
+                }
+            };
         } else {
             return null;
         }

--- a/src/main/java/jnr/posix/util/SunMiscSignal.java
+++ b/src/main/java/jnr/posix/util/SunMiscSignal.java
@@ -11,7 +11,7 @@ public class SunMiscSignal {
 
         if (oldHandler instanceof SunMiscSignalHandler) {
             return ((SunMiscSignalHandler)oldHandler).handler;
-        } else if (oldHandler instanceof sun.misc.SignalHandler) {
+        } else if (oldHandler != null) {
             return new SignalHandler() {
                 @Override
                 public void handle(int signal) {

--- a/src/main/java/jnr/posix/util/SunMiscSignal.java
+++ b/src/main/java/jnr/posix/util/SunMiscSignal.java
@@ -11,6 +11,13 @@ public class SunMiscSignal {
 
         if (oldHandler instanceof SunMiscSignalHandler) {
             return ((SunMiscSignalHandler)oldHandler).handler;
+        } else if (oldHandler instanceof sun.misc.SignalHandler) {
+            return new SignalHandler() {
+                @Override
+                public void handle(int signal) {
+                    oldHandler.handle(s);
+                }
+            };
         } else {
             return null;
         }

--- a/src/main/java/jnr/posix/util/SunMiscSignal.java
+++ b/src/main/java/jnr/posix/util/SunMiscSignal.java
@@ -12,12 +12,7 @@ public class SunMiscSignal {
         if (oldHandler instanceof SunMiscSignalHandler) {
             return ((SunMiscSignalHandler)oldHandler).handler;
         } else if (oldHandler != null) {
-            return new SignalHandler() {
-                @Override
-                public void handle(int signal) {
-                    oldHandler.handle(s);
-                }
-            };
+            return any -> oldHandler.handle(s);
         } else {
             return null;
         }

--- a/src/test/java/jnr/posix/SignalTest.java
+++ b/src/test/java/jnr/posix/SignalTest.java
@@ -51,11 +51,13 @@ public class SignalTest {
         if (!Platform.IS_WINDOWS) {
             Signal s = Signal.SIGHUP;
             final AtomicBoolean fired = new AtomicBoolean(false);
-            javaPosix.signal(s, new SignalHandler() {
+            SignalHandler previousHandler = javaPosix.signal(s, new SignalHandler() {
                 public void handle(int signal) {
                     fired.set(true);
                 }
             });
+
+            Assert.assertNotNull(previousHandler);
 
             // have to use native here; no abstraction for kill in pure Java
             // TODO: sun.misc.Signal.raise can be used to kill current pid


### PR DESCRIPTION
## What changes were proposed in this pull request?

`sun.misc.Signal#handle()` returns the default handler when installing the first custom handler (for each signal).

On the other hand, JNR's `SunMiscSignal#signal()` returns the previous handler only if it is a `SunMiscSignalHandler`, which wraps a custom handler.  When installing the first custom handler (for each signal), `null` is returned.  The default handler is "lost".

This PR fixes that by returning an adapter for the default handler instead of `null`.  This makes it possible to chain handlers, keeping original handler functionality.

## How was this patch tested?

Added assertion in unit test.

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.159 sec - in jnr.posix.SignalTest
```

Also tested in a real application that installs a custom handler (logger) on top of the default functionality.