### PR TITLE
Update jnr-ffi to 2.2.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.2.18</version>
+      <version>2.2.19</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>


### PR DESCRIPTION
Draft until switched to release version of jnr-ffi 2.2.19.